### PR TITLE
feat(WifiTransport): add wifi transport widget

### DIFF
--- a/src/app/flux/cncLaserShared/index.js
+++ b/src/app/flux/cncLaserShared/index.js
@@ -374,6 +374,7 @@ export const actions = {
         headerStart = headerStart.replace(/fileTotalLines/g, fileTotalLines);
 
         gcodeBeans[0].gcode = `${headerStart}\n${gcodeBeans[0].gcode}`;
+        gcodeBeans[0].img = thumbnail;
 
         dispatch(actions.updateState(
             from,

--- a/src/app/flux/widget/WidgetState.js
+++ b/src/app/flux/widget/WidgetState.js
@@ -19,7 +19,7 @@ const defaultState = {
         secondary: {
             show: true,
             widgets: [
-                'webcam', 'axes', 'macro', 'gcode'
+                'wifi-transport', 'axes', 'macro', 'gcode'
             ]
         }
     },

--- a/src/app/flux/workspace/index.js
+++ b/src/app/flux/workspace/index.js
@@ -1,5 +1,6 @@
 // Reducer for Workspace
 import path from 'path';
+import * as THREE from 'three';
 import GcodeInfo from '../models/GcodeInfo';
 
 import api from '../../api';
@@ -11,7 +12,14 @@ const ACTION_ADD_GCODE = 'WORKSPACE/ACTION_ADD_GCODE';
 
 const INITIAL_STATE = {
     gcodeList: [],
-    uploadState: 'idle' // uploading, uploaded
+    uploadState: 'idle', // uploading, uploaded
+    gcodeFiles: [],
+
+
+    background: {
+        enabled: false,
+        group: new THREE.Group()
+    }
 };
 
 
@@ -68,6 +76,19 @@ export const actions = {
         };
     },
 
+    addGcodeFile: (fileInfo) => (dispatch, getState) => {
+        const { gcodeFiles } = getState().workspace;
+        const files = [];
+        files.push(fileInfo);
+        const len = Math.min(gcodeFiles.length, 4);
+        for (let i = 0; i < len; i++) {
+            files.push(gcodeFiles[i]);
+        }
+        dispatch(actions.updateState({
+            gcodeFiles: files
+        }));
+    },
+
     // Clear G-code list
     clearGcode: () => {
         return actions.updateState({ gcodeList: [] });
@@ -89,6 +110,22 @@ export const actions = {
     unloadGcode: () => (dispatch) => {
         // TODO: unload G-code in controller
         dispatch(actions.updateState({ uploadState: 'idle' }));
+    },
+
+    removeBackgroundImage: () => (dispatch, getState) => {
+        const state = getState().workspace;
+        const { group } = state.background;
+        group.remove(...group.children);
+    },
+
+    loadBackgroundToWorkspace: (background) => (dispatch, getState) => {
+        const workspaceBackgroundGroup = getState().workspace.background.group;
+        const backgroundGroup = background.group;
+
+        workspaceBackgroundGroup.remove(...workspaceBackgroundGroup.children);
+        for (const child of backgroundGroup.children) {
+            workspaceBackgroundGroup.add(child.clone());
+        }
     }
 };
 

--- a/src/app/widgets/CNCOutput/Output.jsx
+++ b/src/app/widgets/CNCOutput/Output.jsx
@@ -4,12 +4,13 @@ import FileSaver from 'file-saver';
 import { connect } from 'react-redux';
 import { actions as workspaceActions } from '../../flux/workspace';
 import { actions as sharedActions } from '../../flux/cncLaserShared';
-import { CNC_GCODE_SUFFIX } from '../../constants';
+import { CNC_GCODE_SUFFIX, LASER_GCODE_SUFFIX } from '../../constants';
 import modal from '../../lib/modal';
 import i18n from '../../lib/i18n';
 import { pathWithRandomSuffix } from '../../../shared/lib/random-utils';
 import Thumbnail from '../CncLaserShared/Thumbnail';
 import TipTrigger from '../../components/TipTrigger';
+import api from '../../api';
 
 
 class Output extends PureComponent {
@@ -26,6 +27,7 @@ class Output extends PureComponent {
         gcodeBeans: PropTypes.array.isRequired,
         generateGcode: PropTypes.func.isRequired,
         addGcode: PropTypes.func.isRequired,
+        addGcodeFile: PropTypes.func.isRequired,
         clearGcode: PropTypes.func.isRequired,
         manualPreview: PropTypes.func.isRequired,
         setAutoPreview: PropTypes.func.isRequired
@@ -55,11 +57,44 @@ class Output extends PureComponent {
             for (let i = 0; i < gcodeBeans.length; i++) {
                 const { gcode, modelInfo } = gcodeBeans[i];
                 const renderMethod = (modelInfo.mode === 'greyscale' && modelInfo.config.movementMode === 'greyscale-dot' ? 'point' : 'line');
-                this.props.addGcode('CNC carving object(s).cnc', gcode, renderMethod);
+                const fileName = pathWithRandomSuffix(`${gcodeBeans[i].modelInfo.originalName}.${CNC_GCODE_SUFFIX}`);
+                this.props.addGcode(fileName, gcode, renderMethod);
             }
 
             document.location.href = '/#/workspace';
             window.scrollTo(0, 0);
+
+            this.actions.onSaveGcode();
+        },
+        onSaveGcode: () => {
+            const { gcodeBeans } = this.props;
+            if (gcodeBeans.length === 0) {
+                return;
+            }
+
+            const gcodeArr = [];
+            for (let i = 0; i < gcodeBeans.length; i++) {
+                const { gcode } = gcodeBeans[i];
+                gcodeArr.push(gcode);
+            }
+            const gcodeStr = gcodeArr.join('\n');
+            const blob = new Blob([gcodeStr], { type: 'text/plain;charset=utf-8' });
+            const fileName = `${gcodeBeans[0].modelInfo.originalName}${LASER_GCODE_SUFFIX}`;
+            const file = new File([blob], fileName);
+            const formData = new FormData();
+            formData.append('file', file);
+            api.uploadFile(formData).then((res) => {
+                const response = res.body;
+                this.props.addGcodeFile({
+                    name: fileName,
+                    uploadName: response.uploadName,
+                    size: file.size,
+                    lastModifiedDate: file.lastModifiedDate,
+                    img: gcodeBeans[0].img
+                });
+            }).catch(() => {
+                // Ignore error
+            });
         },
         onExport: () => {
             const { gcodeBeans } = this.props;
@@ -181,6 +216,7 @@ const mapDispatchToProps = (dispatch) => {
     return {
         generateGcode: (thumbnail) => dispatch(sharedActions.generateGcode('cnc', thumbnail)),
         addGcode: (name, gcode, renderMethod) => dispatch(workspaceActions.addGcode(name, gcode, renderMethod)),
+        addGcodeFile: (fileInfo) => dispatch(workspaceActions.addGcodeFile(fileInfo)),
         clearGcode: () => dispatch(workspaceActions.clearGcode()),
         manualPreview: () => dispatch(sharedActions.manualPreview('cnc')),
         setAutoPreview: (value) => dispatch(sharedActions.setAutoPreview('cnc', value))

--- a/src/app/widgets/PrintingOutput/Output.jsx
+++ b/src/app/widgets/PrintingOutput/Output.jsx
@@ -31,6 +31,7 @@ class Output extends PureComponent {
         isAnyModelOverstepped: PropTypes.bool.isRequired,
         generateGcode: PropTypes.func.isRequired,
         addGcode: PropTypes.func.isRequired,
+        addGcodeFile: PropTypes.func.isRequired,
         clearGcode: PropTypes.func.isRequired
     };
 
@@ -61,6 +62,14 @@ class Output extends PureComponent {
             jQuery.get(gcodePath, (result) => {
                 this.props.clearGcode();
                 this.props.addGcode(filename, result);
+
+                this.props.addGcodeFile({
+                    name: filename,
+                    uploadName: filename,
+                    size: result.length,
+                    lastModifiedDate: new Date(),
+                    img: this.thumbnail.current.getDataURL()
+                });
             });
         },
         onClickExportGcode: () => {
@@ -224,6 +233,7 @@ const mapDispatchToProps = (dispatch) => {
     return {
         generateGcode: (thumbnail) => dispatch(printingActions.generateGcode(thumbnail)),
         addGcode: (name, gcode, renderMethod) => dispatch(workspaceActions.addGcode(name, gcode, renderMethod)),
+        addGcodeFile: (fileInfo) => dispatch(workspaceActions.addGcodeFile(fileInfo)),
         clearGcode: () => dispatch(workspaceActions.clearGcode())
     };
 };

--- a/src/app/widgets/PrintingOutput/Thumbnail.jsx
+++ b/src/app/widgets/PrintingOutput/Thumbnail.jsx
@@ -10,6 +10,7 @@ class Thumbnail extends PureComponent {
     };
 
     state = {
+        dataURL: ''
     };
 
     node = React.createRef();
@@ -46,23 +47,6 @@ class Thumbnail extends PureComponent {
         this.renderScene();
     }
 
-    // componentDidUpdate(prevProps) {
-    //     if (this.props.minimized !== prevProps.minimized) {
-    //         const width = this.getVisibleWidth();
-    //         const height = this.getVisibleHeight();
-    //         this.renderer.setSize(width, height);
-    //         this.renderScene();
-    //     }
-    // }
-    //
-    // getVisibleWidth() {
-    //     return this.node.current.parentElement.clientWidth;
-    // }
-    //
-    // getVisibleHeight() {
-    //     return this.node.current.parentElement.clientHeight;
-    // }
-
     getThumbnail() {
         this.object && (this.scene.remove(this.object));
         this.object = this.props.modelGroup.object.clone();
@@ -90,7 +74,16 @@ class Thumbnail extends PureComponent {
 
         this.renderScene();
 
-        return this.renderer.domElement.toDataURL();
+        const toDataURL = this.renderer.domElement.toDataURL();
+        this.setState({
+            dataURL: toDataURL
+        });
+
+        return toDataURL;
+    }
+
+    getDataURL() {
+        return this.state.dataURL;
     }
 
     renderScene() {

--- a/src/app/widgets/Widget.jsx
+++ b/src/app/widgets/Widget.jsx
@@ -20,6 +20,7 @@ import CNCOutputWidget from './CNCOutput';
 import PrintingMaterialWidget from './PrintingMaterial';
 import PrintingConfigurationsWidget from './PrintingConfigurations';
 import PrintingOutputWidget from './PrintingOutput';
+import WifiTransport from './WifiTransport';
 
 
 const getWidgetByName = (name) => {
@@ -35,6 +36,7 @@ const getWidgetByName = (name) => {
         'marlin': MarlinWidget,
         'visualizer': VisualizerWidget,
         'webcam': WebcamWidget,
+        'wifi-transport': WifiTransport,
         '3dp-material': PrintingMaterialWidget,
         '3dp-configurations': PrintingConfigurationsWidget,
         '3dp-output': PrintingOutputWidget,

--- a/src/app/widgets/WifiTransport/WifiTransport.jsx
+++ b/src/app/widgets/WifiTransport/WifiTransport.jsx
@@ -1,0 +1,222 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import _ from 'lodash';
+import jQuery from 'jquery';
+import Anchor from '../../components/Anchor';
+import i18n from '../../lib/i18n';
+import widgetStyles from '../styles.styl';
+import styles from './index.styl';
+import { DATA_PREFIX } from '../../constants';
+import { actions as workspaceActions } from '../../flux/workspace';
+import api from '../../api';
+
+
+// import controller from '../../lib/controller';
+
+
+class WifiTransport extends PureComponent {
+    static propTypes = {
+        setTitle: PropTypes.func.isRequired,
+
+        gcodeFiles: PropTypes.array.isRequired,
+        isConnected: PropTypes.bool.isRequired,
+        server: PropTypes.object.isRequired,
+
+        clearGcode: PropTypes.func.isRequired,
+        addGcode: PropTypes.func.isRequired,
+        addGcodeFile: PropTypes.func.isRequired
+    };
+
+    fileInput = React.createRef();
+
+    state = {
+        selectFileName: ''
+    };
+
+    actions = {
+        onSelectFile: (selectFileName) => {
+            if (this.state.selectFileName === selectFileName) {
+                this.setState({
+                    selectFileName: ''
+                });
+            } else {
+                this.setState({
+                    selectFileName: selectFileName
+                });
+            }
+        },
+        onChangeFile: async (event) => {
+            const file = event.target.files[0];
+            const formData = new FormData();
+            formData.append('file', file);
+            api.uploadFile(formData)
+                .then((res) => {
+                    const response = res.body;
+                    this.props.addGcodeFile({
+                        name: file.name,
+                        uploadName: response.uploadName,
+                        size: file.size,
+                        lastModifiedDate: file.lastModifiedDate,
+                        img: ''
+                    });
+                })
+                .catch(() => {
+                    // Ignore error
+                });
+        },
+        onClickToUpload: () => {
+            this.fileInput.current.value = null;
+            this.fileInput.current.click();
+        },
+        sendFile: () => {
+            console.log(this.props.isConnected);
+            console.log(this.props.server);
+        },
+        loadGcodeToWorkspace: () => {
+            const selectFileName = this.state.selectFileName;
+            const find = this.props.gcodeFiles.find(v => v.name === selectFileName);
+            if (!find) {
+                return;
+            }
+            const gcodePath = `${DATA_PREFIX}/${find.uploadName}`;
+            jQuery.get(gcodePath, (result) => {
+                this.props.clearGcode();
+                this.props.addGcode(selectFileName, result);
+            });
+        }
+    };
+
+
+    constructor(props) {
+        super(props);
+        this.props.setTitle(i18n._('Wi-Fi Transport'));
+    }
+
+    render() {
+        const { gcodeFiles } = this.props;
+        const { selectFileName } = this.state;
+        const actions = this.actions;
+        const hasFile = gcodeFiles.length > 0;
+
+        return (
+            <div>
+                <input
+                    ref={this.fileInput}
+                    type="file"
+                    accept=".gcode, .nc .cnc"
+                    style={{ display: 'none' }}
+                    multiple={false}
+                    onChange={actions.onChangeFile}
+                />
+                <button
+                    type="button"
+                    className="sm-btn-small sm-btn-default"
+                    onClick={actions.onClickToUpload}
+                    style={{ display: 'block', width: '50%' }}
+                >
+                    {i18n._('Upload File')}
+                </button>
+                {hasFile && (
+                    <div>
+                        <div style={{
+                            'marginTop': '6px'
+                        }}
+                        >
+                            {i18n._('Stack')}
+                        </div>
+                        <div className={classNames(widgetStyles.separator, widgetStyles['separator-underline'])} />
+
+                        {_.map(gcodeFiles, (gcodeFile) => {
+                            const name = gcodeFile.name.length > 33
+                                ? `${gcodeFile.name.substring(0, 15)}......${gcodeFile.name.substring(gcodeFile.name.length - 10, gcodeFile.name.length)}`
+                                : gcodeFile.name;
+                            let size = '';
+                            if (gcodeFile.size / 1024 / 1024 > 1) {
+                                size = `${(gcodeFile.size / 1024 / 1024).toFixed(2)} MB`;
+                            } else if (gcodeFile.size / 1024 > 1) {
+                                size = `${(gcodeFile.size / 1024).toFixed(2)} KB`;
+                            } else {
+                                size = `${(gcodeFile.size).toFixed(2)} B`;
+                            }
+                            const lastModifiedDate = gcodeFile.lastModifiedDate;
+                            const date = `${lastModifiedDate.getFullYear()}.${lastModifiedDate.getMonth()}.${lastModifiedDate.getDay()}   ${lastModifiedDate.getHours()}:${lastModifiedDate.getMinutes()}`;
+
+                            return (
+                                <div key={gcodeFile.uploadName}>
+                                    <Anchor
+                                        className={classNames(
+                                            styles['gcode-file'],
+                                            { [styles.selected]: selectFileName === gcodeFile.name }
+                                        )}
+                                        onClick={() => {
+                                            actions.onSelectFile(gcodeFile.name);
+                                        }}
+                                    >
+                                        <div className={styles['gcode-file-img']}>
+                                            <img
+                                                src={gcodeFile.img}
+                                                alt=""
+                                            />
+                                        </div>
+                                        <div className={styles['gcode-file-text']}>
+                                            <div className={styles['gcode-file-text-name']}>
+                                                {name}
+                                            </div>
+                                            <div className={styles['gcode-file-text-info']}>
+                                                <span>{size}</span>
+                                                <span>{date}</span>
+                                            </div>
+                                        </div>
+                                    </Anchor>
+                                </div>
+                            );
+                        })}
+
+                        <div className={classNames(widgetStyles.separator, widgetStyles['separator-underline'])} />
+                        <button
+                            type="button"
+                            className="sm-btn-small sm-btn-default"
+                            onClick={actions.loadGcodeToWorkspace}
+                            style={{ display: 'block', width: '100%', marginBottom: '10px' }}
+                        >
+                            {i18n._('Load G-code to Workspace')}
+                        </button>
+                        <button
+                            type="button"
+                            className="sm-btn-small sm-btn-default"
+                            onClick={actions.removeBackgroundImage}
+                            style={{ display: 'block', width: '100%' }}
+                        >
+                            {i18n._('Transfer By WiFi')}
+                        </button>
+                    </div>
+                )}
+            </div>
+
+        );
+    }
+}
+
+const mapStateToProps = (state) => {
+    const { gcodeFiles } = state.workspace;
+    const { server, isConnected } = state.machine;
+
+    return {
+        gcodeFiles,
+        server,
+        isConnected
+    };
+};
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        clearGcode: () => dispatch(workspaceActions.clearGcode()),
+        addGcode: (name, gcode, renderMethod) => dispatch(workspaceActions.addGcode(name, gcode, renderMethod)),
+        addGcodeFile: (fileInfo) => dispatch(workspaceActions.addGcodeFile(fileInfo))
+    };
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(WifiTransport);

--- a/src/app/widgets/WifiTransport/index.jsx
+++ b/src/app/widgets/WifiTransport/index.jsx
@@ -1,0 +1,4 @@
+import { createDefaultWidget } from '../../components/SMWidget';
+import WifiTransport from './WifiTransport';
+
+export default createDefaultWidget(WifiTransport);

--- a/src/app/widgets/WifiTransport/index.styl
+++ b/src/app/widgets/WifiTransport/index.styl
@@ -1,0 +1,39 @@
+@import "../../styles/variables.styl"
+
+.gcode-file
+    display: block
+    margin-bottom: 6px
+    border: 1px solid
+    border-color: $grey-color2
+    border-radius: $border-radius
+    height: 50px
+    padding: 6px
+
+    &.selected
+        border-color: $blue-color
+
+    &-img
+        display: inline-block
+        height: 100%
+        width: 54px
+        vertical-align: top
+        margin-right: 6px
+
+        img
+            height:100%
+
+    &-text
+        display: inline-block
+        height: 100%
+        width: 60%
+        white-space: nowrap
+
+        &-name
+            font-size: 14px
+        &-info
+            font-size: 12px
+            color: $grey-color
+            vertical-align: bottom
+
+            span
+                margin-right: 12px

--- a/src/app/widgets/WorkspaceVisualizer/Visualizer.jsx
+++ b/src/app/widgets/WorkspaceVisualizer/Visualizer.jsx
@@ -54,7 +54,8 @@ class Visualizer extends Component {
         addGcode: PropTypes.func.isRequired,
         clearGcode: PropTypes.func.isRequired,
         loadGcode: PropTypes.func.isRequired,
-        unloadGcode: PropTypes.func.isRequired
+        unloadGcode: PropTypes.func.isRequired,
+        backgroundGroup: PropTypes.object.isRequired
     };
 
     printableArea = null;
@@ -790,6 +791,7 @@ class Visualizer extends Component {
                     <Canvas
                         ref={this.canvas}
                         size={this.props.size}
+                        backgroundGroup={this.props.backgroundGroup}
                         modelGroup={this.modelGroup}
                         printableArea={this.printableArea}
                         cameraInitialPosition={new THREE.Vector3(0, 0, 150)}
@@ -844,7 +846,8 @@ const mapStateToProps = (state) => {
         isConnected: machine.isConnected,
         connectionType: machine.connectionType,
         uploadState: workspace.uploadState,
-        gcodeList: workspace.gcodeList
+        gcodeList: workspace.gcodeList,
+        backgroundGroup: workspace.background.group
     };
 };
 


### PR DESCRIPTION
this widget store historical gcode files for loading to workspace and sending to screen

- The maximum number of history files is 5
- The widget will save gcode file when click the 3dp/laser/CNC load to workspace button