### PR TITLE
Refactor: Refactor three.js code to make XYZ directions the as natura…

### DIFF
--- a/src/app/components/SMCanvas/ArcGeometry.js
+++ b/src/app/components/SMCanvas/ArcGeometry.js
@@ -22,7 +22,7 @@ class ArcBufferGeometry extends THREE.BufferGeometry {
 
         const count = segments * thetaLength / (Math.PI * 2);
         for (let i = 0; i <= count; i++) {
-            vertices.push(0, Math.cos(i / segments * Math.PI * 2) * radius, Math.sin(i / segments * Math.PI * 2) * radius);
+            vertices.push(Math.cos(i / segments * Math.PI * 2) * radius, Math.sin(i / segments * Math.PI * 2) * radius, 0);
         }
 
         this.addAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));

--- a/src/app/components/SMCanvas/Canvas.jsx
+++ b/src/app/components/SMCanvas/Canvas.jsx
@@ -29,6 +29,8 @@ class Canvas extends Component {
         toolPathModelGroup: PropTypes.object,
         gcodeLineGroup: PropTypes.object,
         cameraInitialPosition: PropTypes.object.isRequired,
+        cameraInitialTarget: PropTypes.object.isRequired,
+        cameraUp: PropTypes.object,
         // callback
         onSelectModel: PropTypes.func,
         onUnselectAllModels: PropTypes.func,
@@ -118,6 +120,11 @@ class Canvas extends Component {
         this.camera = new PerspectiveCamera(45, width / height, 0.1, 10000);
         this.camera.position.copy(this.cameraInitialPosition);
 
+        // We need to change the default up vector if we use camera to respect XY plane
+        if (this.props.cameraUp) {
+            this.camera.up = this.props.cameraUp;
+        }
+
         this.renderer = new WebGLRenderer({ antialias: true });
         this.renderer.setClearColor(new Color(0xfafafa), 1);
         this.renderer.setSize(width, height);
@@ -136,7 +143,7 @@ class Canvas extends Component {
     }
 
     setupControls() {
-        this.initialTarget.set(this.cameraInitialPosition.x, this.cameraInitialPosition.y, 0);
+        this.initialTarget = this.props.cameraInitialTarget;
 
         const sourceType = this.props.transformSourceType === '2D' ? '2D' : '3D';
 
@@ -252,7 +259,7 @@ class Canvas extends Component {
     autoFocus(model) {
         this.camera.position.copy(this.cameraInitialPosition);
 
-        const target = model ? model.position.clone() : new Vector3(0, this.cameraInitialPosition.y, 0);
+        const target = model ? model.position.clone() : this.initialTarget;
         this.controls.setTarget(target);
 
         const object = {
@@ -279,9 +286,10 @@ class Canvas extends Component {
     }
 
     toLeft() {
-        this.camera.rotation.x = 0;
+        this.camera.rotation.x = Math.PI / 2;
         this.camera.rotation.z = 0;
 
+        // BTH, I don't know why Y rotation is applied before X rotation, so here we can't change rotation.z
         const object = {
             rotationY: this.camera.rotation.y
         };
@@ -296,14 +304,14 @@ class Canvas extends Component {
                 this.camera.rotation.y = rotation;
 
                 this.camera.position.x = this.controls.target.x + Math.sin(rotation) * dist;
-                this.camera.position.y = this.controls.target.y;
-                this.camera.position.z = this.controls.target.z + Math.cos(rotation) * dist;
+                this.camera.position.y = this.controls.target.y - Math.cos(rotation) * dist;
+                this.camera.position.z = this.controls.target.z;
             });
         this.startTween(tween);
     }
 
     toRight() {
-        this.camera.rotation.x = 0;
+        this.camera.rotation.x = Math.PI / 2;
         this.camera.rotation.z = 0;
 
         const object = {
@@ -320,8 +328,8 @@ class Canvas extends Component {
                 this.camera.rotation.y = rotation;
 
                 this.camera.position.x = this.controls.target.x + Math.sin(rotation) * dist;
-                this.camera.position.y = this.controls.target.y;
-                this.camera.position.z = this.controls.target.z + Math.cos(rotation) * dist;
+                this.camera.position.y = this.controls.target.y - Math.cos(rotation) * dist;
+                this.camera.position.z = this.controls.target.z;
             });
         this.startTween(tween);
     }

--- a/src/app/components/SMCanvas/Controls.jsx
+++ b/src/app/components/SMCanvas/Controls.jsx
@@ -397,14 +397,18 @@ class Controls extends EventEmitter {
     updateCamera() {
         this.offset.copy(this.camera.position).sub(this.target);
 
-        const offsetXZ = new THREE.Vector3();
+        const spherialOffset = new THREE.Vector3();
 
         // rotate & scale
         if (this.sphericalDelta.theta !== 0 || this.sphericalDelta.phi !== 0 || this.scale !== 1) {
             // Spherical is based on XZ plane, instead of implement a new spherical on XY plane
             // we use a Vector3 to swap Y and Z as a little calculation trick.
-            offsetXZ.set(this.offset.x, this.offset.z, -this.offset.y);
-            this.spherical.setFromVector3(offsetXZ);
+            if (this.camera.up.z === 1) {
+                spherialOffset.set(this.offset.x, this.offset.z, -this.offset.y);
+            } else {
+                spherialOffset.copy(this.offset);
+            }
+            this.spherical.setFromVector3(spherialOffset);
 
             this.spherical.theta += this.sphericalDelta.theta;
             this.spherical.phi += this.sphericalDelta.phi;
@@ -413,8 +417,13 @@ class Controls extends EventEmitter {
             this.spherical.radius *= this.scale;
             this.spherical.radius = Math.max(this.spherical.radius, 0.05);
 
-            offsetXZ.setFromSpherical(this.spherical);
-            this.offset.set(offsetXZ.x, -offsetXZ.z, offsetXZ.y);
+            spherialOffset.setFromSpherical(this.spherical);
+
+            if (this.camera.up.z === 1) {
+                this.offset.set(spherialOffset.x, -spherialOffset.z, spherialOffset.y);
+            } else {
+                this.offset.copy(spherialOffset);
+            }
 
             this.sphericalDelta.set(0, 0, 0);
             this.scale = 1;

--- a/src/app/components/SMCanvas/Controls.jsx
+++ b/src/app/components/SMCanvas/Controls.jsx
@@ -397,9 +397,15 @@ class Controls extends EventEmitter {
     updateCamera() {
         this.offset.copy(this.camera.position).sub(this.target);
 
+        const offsetXZ = new THREE.Vector3();
+
         // rotate & scale
         if (this.sphericalDelta.theta !== 0 || this.sphericalDelta.phi !== 0 || this.scale !== 1) {
-            this.spherical.setFromVector3(this.offset);
+            // Spherical is based on XZ plane, instead of implement a new spherical on XY plane
+            // we use a Vector3 to swap Y and Z as a little calculation trick.
+            offsetXZ.set(this.offset.x, this.offset.z, -this.offset.y);
+            this.spherical.setFromVector3(offsetXZ);
+
             this.spherical.theta += this.sphericalDelta.theta;
             this.spherical.phi += this.sphericalDelta.phi;
             this.spherical.makeSafe();
@@ -407,7 +413,8 @@ class Controls extends EventEmitter {
             this.spherical.radius *= this.scale;
             this.spherical.radius = Math.max(this.spherical.radius, 0.05);
 
-            this.offset.setFromSpherical(this.spherical);
+            offsetXZ.setFromSpherical(this.spherical);
+            this.offset.set(offsetXZ.x, -offsetXZ.z, offsetXZ.y);
 
             this.sphericalDelta.set(0, 0, 0);
             this.scale = 1;

--- a/src/app/components/SMCanvas/TransformControls.js
+++ b/src/app/components/SMCanvas/TransformControls.js
@@ -1,10 +1,21 @@
 import {
-    Vector3, Quaternion, Matrix4,
-    Object3D, Raycaster,
-    Mesh, Line,
-    BufferGeometry, BoxBufferGeometry, PlaneBufferGeometry, CylinderBufferGeometry, OctahedronBufferGeometry, TorusBufferGeometry,
-    MeshBasicMaterial, LineBasicMaterial,
-    Float32BufferAttribute, DoubleSide
+    DoubleSide,
+    Float32BufferAttribute,
+    Vector3,
+    Quaternion,
+    Matrix4,
+    Object3D,
+    Raycaster,
+    Mesh,
+    Line,
+    BufferGeometry,
+    BoxBufferGeometry,
+    PlaneBufferGeometry,
+    CylinderBufferGeometry,
+    OctahedronBufferGeometry,
+    TorusBufferGeometry,
+    MeshBasicMaterial,
+    LineBasicMaterial
 } from 'three';
 import { ArcBufferGeometry } from './ArcGeometry';
 
@@ -193,12 +204,12 @@ class TransformControls extends Object3D {
         const defaults = this.defaults;
 
         this.translatePeripheral = this.createPeripheral([
-            ['X', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_RED.clone()), [1, 0, 0], [0, 0, -Math.PI / 2]],
             ['X', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_RED.clone())],
-            ['Y', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_BLUE.clone()), [0, 1, 0]],
-            ['Y', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_BLUE.clone()), null, [0, 0, Math.PI / 2]],
-            ['Z', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_GREEN.clone()), [0, 0, -1], [-Math.PI / 2, 0, 0]],
-            ['Z', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_GREEN.clone()), null, [0, Math.PI / 2, 0]]
+            ['X', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_RED.clone()), [1, 0, 0], [0, 0, -Math.PI / 2]],
+            ['Y', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_GREEN.clone()), null, [0, 0, Math.PI / 2]],
+            ['Y', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_GREEN.clone()), [0, 1, 0]],
+            ['Z', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_BLUE.clone()), null, [0, -Math.PI / 2, 0]],
+            ['Z', new Mesh(defaults.ARROW.clone(), defaults.MESH_MATERIAL_BLUE.clone()), [0, 0, 1], [Math.PI / 2, 0, 0]]
         ]);
         this.translatePeripheral.visible = false;
         this.add(this.translatePeripheral);
@@ -206,7 +217,7 @@ class TransformControls extends Object3D {
         this.translatePicker = this.createPeripheral([
             ['X', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0.6, 0, 0], [0, 0, -Math.PI / 2]],
             ['Y', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0.6, 0]],
-            ['Z', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0, -0.6], [-Math.PI / 2, 0, 0]]
+            ['Z', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0, 0.6], [Math.PI / 2, 0, 0]]
         ]);
         this.translatePicker.visiable = false;
         this.add(this.translatePicker);
@@ -216,13 +227,13 @@ class TransformControls extends Object3D {
         const defaults = this.defaults;
 
         this.rotatePeripheral = this.createPeripheral([
-            ['X', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_RED.clone())],
-            ['X', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_RED.clone()), [0, 0, 0.99], null, [1, 3, 1]],
-            ['Y', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_BLUE.clone()), null, [0, 0, Math.PI / 2]],
-            ['Y', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_BLUE.clone()), [0, 0, 0.99], [0, 0, Math.PI / 2], [1, 3, 1]],
-            ['Z', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_GREEN.clone()), null, [0, Math.PI / 2, 0]],
-            ['Z', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_GREEN.clone()), [0.99, 0, 0], null, [1, 3, 1]],
-            ['XYZE', new Line(new ArcBufferGeometry(1, 64, Math.PI * 2), defaults.LINE_MATERIAL_GRAY.clone()), null, [0, Math.PI / 2, 0]]
+            ['X', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_RED.clone()), null, [Math.PI, Math.PI / 2, 0]],
+            ['X', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_RED.clone()), [0, -0.99, 0], [Math.PI / 2, 0, 0], [1, 3, 1]],
+            ['Y', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_GREEN.clone()), null, [Math.PI / 2, 0, 0]],
+            ['Y', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_GREEN.clone()), [0, 0, 0.99], [0, 0, Math.PI / 2], [1, 3, 1]],
+            ['Z', new Line(new ArcBufferGeometry(1, 64, Math.PI), defaults.LINE_MATERIAL_BLUE.clone()), null, [Math.PI, 0, 0]],
+            ['Z', new Mesh(new OctahedronBufferGeometry(0.04, 0), defaults.MESH_MATERIAL_BLUE.clone()), [0, -0.99, 0], [0, 0, Math.PI / 2], [1, 3, 1]],
+            ['XYZE', new Line(new ArcBufferGeometry(1, 64, Math.PI * 2), defaults.LINE_MATERIAL_GRAY.clone()), null, [0, 0, 0]]
         ]);
         this.add(this.rotatePeripheral);
 
@@ -241,17 +252,17 @@ class TransformControls extends Object3D {
         this.scalePeripheral = this.createPeripheral([
             ['X', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_RED.clone())],
             ['X', new Mesh(defaults.BOX.clone(), defaults.MESH_MATERIAL_RED.clone()), [1, 0, 0], [0, 0, -Math.PI / 2]],
-            ['Y', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_BLUE.clone()), null, [0, 0, Math.PI / 2]],
-            ['Y', new Mesh(defaults.BOX.clone(), defaults.MESH_MATERIAL_BLUE.clone()), [0, 1, 0]],
-            ['Z', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_GREEN.clone()), null, [0, Math.PI / 2, 0]],
-            ['Z', new Mesh(defaults.BOX.clone(), defaults.MESH_MATERIAL_GREEN.clone()), [0, 0, -1], [-Math.PI / 2, 0, 0]]
+            ['Y', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_GREEN.clone()), null, [0, 0, Math.PI / 2]],
+            ['Y', new Mesh(defaults.BOX.clone(), defaults.MESH_MATERIAL_GREEN.clone()), [0, 1, 0]],
+            ['Z', new Line(defaults.LINE.clone(), defaults.LINE_MATERIAL_BLUE.clone()), null, [0, -Math.PI / 2, 0]],
+            ['Z', new Mesh(defaults.BOX.clone(), defaults.MESH_MATERIAL_BLUE.clone()), [0, 0, 1], [Math.PI / 2, 0, 0]]
         ]);
         this.add(this.scalePeripheral);
 
         this.scalePicker = this.createPeripheral([
             ['X', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0.6, 0, 0], [0, 0, -Math.PI / 2]],
             ['Y', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0.6, 0]],
-            ['Z', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0, -0.6], [-Math.PI / 2, 0, 0]]
+            ['Z', new Mesh(defaults.TRANSLATE_PICKER.clone(), defaults.MESH_MATERIAL_INVISIBLE), [0, 0, 0.6], [Math.PI / 2, 0, 0]]
         ]);
         this.scalePicker.visiable = false;
         this.add(this.scalePicker);
@@ -357,19 +368,19 @@ class TransformControls extends Object3D {
             // Highlight peripherals internals based on axis selected
             for (const handle of handles) {
                 if (this.mode === 'rotate') {
-                    const alignVector = new Vector3().copy(cameraPosition);
+                    const alignVector = new Vector3().copy(cameraPosition).sub(objectPosition);
 
                     if (handle.label === 'X') {
-                        const quaternion = new Quaternion().setFromAxisAngle(unitX, Math.atan2(-alignVector.y, alignVector.z));
+                        const quaternion = new Quaternion().setFromAxisAngle(unitX, Math.atan2(-alignVector.z, -alignVector.y));
                         handle.quaternion.copy(quaternion);
                     } else if (handle.label === 'Y') {
                         const quaternion = new Quaternion().setFromAxisAngle(unitY, Math.atan2(alignVector.x, alignVector.z));
                         handle.quaternion.copy(quaternion);
                     } else if (handle.label === 'Z') {
-                        const quaternion = new Quaternion().setFromAxisAngle(unitZ, Math.atan2(alignVector.y, alignVector.x));
+                        const quaternion = new Quaternion().setFromAxisAngle(unitZ, Math.atan2(alignVector.x, -alignVector.y));
                         handle.quaternion.copy(quaternion);
                     } else if (handle.label === 'XYZE') {
-                        const rotationMatrix = new Matrix4().lookAt(cameraPosition, zero, unitY);
+                        const rotationMatrix = new Matrix4().lookAt(cameraPosition, objectPosition, unitZ);
                         handle.quaternion.setFromRotationMatrix(rotationMatrix);
                     }
                 }

--- a/src/app/components/three-extensions/OBJExporter.js
+++ b/src/app/components/three-extensions/OBJExporter.js
@@ -80,9 +80,7 @@ OBJExporter.prototype = {
                         vertex.applyMatrix4( mesh.matrix );
 
 						// transform the vertex to export format
-                        // output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
-                        // modified by Walker
-						output += 'v ' + vertex.x + ' ' + (-vertex.z) + ' ' + vertex.y + '\n';
+                        output += 'v ' + vertex.x + ' ' + vertex.y + ' ' + vertex.z + '\n';
 
 					}
 

--- a/src/app/components/three-extensions/STLBinaryExporter.js
+++ b/src/app/components/three-extensions/STLBinaryExporter.js
@@ -84,13 +84,9 @@ STLBinaryExporter.prototype = {
 
 						vector.copy( vertices[ indices[ j ] ] ).applyMatrix4( object.matrix );
 
-						// output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
-						// output.setFloat32( offset, vector.y, true ); offset += 4;
-						// output.setFloat32( offset, vector.z, true ); offset += 4;
-
-                        output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
-                        output.setFloat32( offset, -vector.z, true ); offset += 4;
-                        output.setFloat32( offset, vector.y, true ); offset += 4;
+						output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
+						output.setFloat32( offset, vector.y, true ); offset += 4;
+						output.setFloat32( offset, vector.z, true ); offset += 4;
 
 					}
 

--- a/src/app/components/three-extensions/STLExporter.js
+++ b/src/app/components/three-extensions/STLExporter.js
@@ -62,8 +62,7 @@ STLExporter.prototype = {
 
 								vector.copy( vertices[ indices[ j ] ] ).applyMatrix4( matrixLocal );
 
-                                // output += '\t\t\tvertex ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
-								output += '\t\t\tvertex ' + vector.x + ' ' + (-vector.z) + ' ' + vector.y + '\n';
+                                output += '\t\t\tvertex ' + vector.x + ' ' + vector.y + ' ' + vector.z + '\n';
 
 							}
 

--- a/src/app/three-extensions/objects/Grid.js
+++ b/src/app/three-extensions/objects/Grid.js
@@ -1,0 +1,65 @@
+import {
+    Color, Float32BufferAttribute, VertexColors,
+    BufferGeometry, LineBasicMaterial, LineSegments
+} from 'three';
+
+
+class Grid extends LineSegments {
+    /**
+     * Create a Grid object on XY plane, starting at (0, 0, 0).
+     *
+     * @param width width of grid (along X axis)
+     * @param height height of grid (along Y axis)
+     * @param step grid cells are squares, step is the length of square
+     * @param color integer color value of grid lines
+     * @returns {Grid}
+     */
+    static createGrid(width, height, step, color) {
+        width = width || 10;
+        height = height || 10;
+        step = step || 1;
+        color = new Color(color !== undefined ? color : 0xd8d8d8);
+
+        const hWidth = width / 2, hHeight = height / 2;
+
+        const vertices = [], colors = [];
+
+        // vertical segments
+        let offset = 0;
+        for (let x = -hWidth; x <= hWidth; x += step) {
+            vertices.push(x, -hHeight, 0, x, hHeight, 0);
+
+            color.toArray(colors, offset);
+            offset += 3;
+            color.toArray(colors, offset);
+            offset += 3;
+        }
+
+        // horizontal segments
+        for (let y = -hHeight; y <= hHeight; y += step) {
+            vertices.push(-hWidth, y, 0, hWidth, y, 0);
+
+            color.toArray(colors, offset);
+            offset += 3;
+            color.toArray(colors, offset);
+            offset += 3;
+        }
+
+        const geometry = new BufferGeometry();
+        geometry.addAttribute('position', new Float32BufferAttribute(vertices, 3));
+        geometry.addAttribute('color', new Float32BufferAttribute(colors, 3));
+
+        const material = new LineBasicMaterial({ vertexColors: VertexColors });
+
+        return new Grid(geometry, material);
+    }
+
+    constructor(geometry, material) {
+        super(geometry, material);
+
+        // this.type = 'LineSegments';
+        this.type = 'Grid';
+    }
+}
+
+export default Grid;

--- a/src/app/three-extensions/objects/Rectangle.js
+++ b/src/app/three-extensions/objects/Rectangle.js
@@ -1,0 +1,53 @@
+import {
+    Color, Float32BufferAttribute, VertexColors,
+    BufferGeometry, LineBasicMaterial, LineSegments
+} from 'three';
+
+class Rectangle extends LineSegments {
+    /**
+     * Create a Rectangle object on XY plane, starting at (0, 0, 0).
+     *
+     * @param width width of rectangle (along X axis)
+     * @param height height of rectangle (along Y axis)
+     * @param color integer color value of rectangle lines
+     * @returns {Rectangle}
+     */
+    static createRectangle(width, height, color) {
+        width = width || 10;
+        height = height || 10;
+        color = new Color(color !== undefined ? color : 0xc8c8c8);
+
+        const hWidth = width / 2, hHeight = height / 2;
+
+        const vertices = [], colors = [];
+
+        // horizontal segments
+        vertices.push(-hWidth, -hHeight, 0, hWidth, -hHeight, 0);
+        vertices.push(-hWidth, hHeight, 0, hWidth, hHeight, 0);
+
+        // vertical segments
+        vertices.push(-hWidth, -hHeight, 0, -hWidth, hHeight, 0);
+        vertices.push(hWidth, -hHeight, 0, hWidth, hHeight, 0);
+
+        for (let offset = 0; offset < 8 * 3; offset += 3) {
+            color.toArray(colors, offset);
+        }
+
+        const geometry = new BufferGeometry();
+        geometry.addAttribute('position', new Float32BufferAttribute(vertices, 3));
+        geometry.addAttribute('color', new Float32BufferAttribute(colors, 3));
+
+        const material = new LineBasicMaterial({ vertexColors: VertexColors });
+
+        return new Rectangle(geometry, material);
+    }
+
+    constructor(geometry, material) {
+        super(geometry, material);
+
+        // this.type = 'LineSegments';
+        this.type = 'Rectangle';
+    }
+}
+
+export default Rectangle;

--- a/src/app/widgets/CNCVisualizer/Visualizer.jsx
+++ b/src/app/widgets/CNCVisualizer/Visualizer.jsx
@@ -155,7 +155,7 @@ class Visualizer extends Component {
         if (!isEqual(nextProps.size, this.props.size)) {
             const size = nextProps.size;
             this.printableArea.updateSize(size);
-            this.canvas.current.setCamera(new THREE.Vector3(0, 0, Math.min(size.z * 2, 300)), new THREE.Vector3());
+            this.canvas.current.setCamera(new THREE.Vector3(0, 0, Math.min(size.z, 300)), new THREE.Vector3());
         }
 
         // TODO: find better way
@@ -328,8 +328,8 @@ class Visualizer extends Component {
                         modelGroup={this.props.modelGroup.object}
                         toolPathModelGroup={this.props.toolPathModelGroup.object}
                         printableArea={this.printableArea}
-                        cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
-                        cameraInitialTarget={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
+                        cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z, 300))}
+                        cameraInitialTarget={new THREE.Vector3(0, 0, 0)}
                         onSelectModel={this.actions.onSelectModel}
                         onUnselectAllModels={this.actions.onUnselectAllModels}
                         onModelAfterTransform={this.actions.onModelAfterTransform}

--- a/src/app/widgets/CNCVisualizer/Visualizer.jsx
+++ b/src/app/widgets/CNCVisualizer/Visualizer.jsx
@@ -329,6 +329,7 @@ class Visualizer extends Component {
                         toolPathModelGroup={this.props.toolPathModelGroup.object}
                         printableArea={this.printableArea}
                         cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
+                        cameraInitialTarget={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
                         onSelectModel={this.actions.onSelectModel}
                         onUnselectAllModels={this.actions.onUnselectAllModels}
                         onModelAfterTransform={this.actions.onModelAfterTransform}

--- a/src/app/widgets/CncLaserShared/PrintablePlate/PrintablePlate.jsx
+++ b/src/app/widgets/CncLaserShared/PrintablePlate/PrintablePlate.jsx
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import { MeshBasicMaterial, Object3D, Group, CylinderBufferGeometry, Mesh } from 'three';
 import each from 'lodash/each';
 import colornames from 'colornames';
 
@@ -11,7 +11,8 @@ import CoordinateAxes from './CoordinateAxes';
 
 const METRIC_GRID_SPACING = 10; // 10 mm
 
-class PrintablePlate extends THREE.Object3D {
+
+class PrintablePlate extends Object3D {
     constructor(size) {
         super();
         this.isPrintPlane = true;
@@ -35,7 +36,7 @@ class PrintablePlate extends THREE.Object3D {
         const axisXLength = Math.ceil(this.size.x / gridSpacing) * gridSpacing;
         const axisYLength = Math.ceil(this.size.y / gridSpacing) * gridSpacing;
 
-        const group = new THREE.Group();
+        const group = new Group();
 
         { // Coordinate Grid
             const gridLine = new GridLine(
@@ -60,17 +61,17 @@ class PrintablePlate extends THREE.Object3D {
             coordinateAxes.name = 'CoordinateAxes';
             group.add(coordinateAxes);
 
-            const arrowX = new THREE.Mesh(
-                new THREE.CylinderBufferGeometry(0, 1, 4),
-                new THREE.MeshBasicMaterial({ color: RED })
+            const arrowX = new Mesh(
+                new CylinderBufferGeometry(0, 1, 4),
+                new MeshBasicMaterial({ color: RED })
             );
             arrowX.position.set(axisXLength + 2, 0, 0);
             arrowX.rotation.set(0, 0, -Math.PI / 2);
             group.add(arrowX);
 
-            const arrowY = new THREE.Mesh(
-                new THREE.CylinderBufferGeometry(0, 1, 4),
-                new THREE.MeshBasicMaterial({ color: GREEN })
+            const arrowY = new Mesh(
+                new CylinderBufferGeometry(0, 1, 4),
+                new MeshBasicMaterial({ color: GREEN })
             );
             arrowY.position.set(0, axisYLength + 2, 0);
             group.add(arrowY);

--- a/src/app/widgets/LaserVisualizer/Visualizer.jsx
+++ b/src/app/widgets/LaserVisualizer/Visualizer.jsx
@@ -160,7 +160,7 @@ class Visualizer extends Component {
         if (!isEqual(nextProps.size, this.props.size)) {
             const size = nextProps.size;
             this.printableArea.updateSize(size);
-            this.canvas.current.setCamera(new THREE.Vector3(0, 0, Math.min(size.z * 2, 300)), new THREE.Vector3());
+            this.canvas.current.setCamera(new THREE.Vector3(0, 0, Math.min(size.z, 300)), new THREE.Vector3());
         }
 
         /*
@@ -288,8 +288,8 @@ class Visualizer extends Component {
                         modelGroup={this.props.modelGroup.object}
                         toolPathModelGroup={this.props.toolPathModelGroup.object}
                         printableArea={this.printableArea}
-                        cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
-                        cameraInitialTarget={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
+                        cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z, 300))}
+                        cameraInitialTarget={new THREE.Vector3(0, 0, 0)}
                         onSelectModel={this.actions.onSelectModel}
                         onUnselectAllModels={this.actions.onUnselectAllModels}
                         onModelAfterTransform={this.actions.onModelAfterTransform}

--- a/src/app/widgets/LaserVisualizer/Visualizer.jsx
+++ b/src/app/widgets/LaserVisualizer/Visualizer.jsx
@@ -289,6 +289,7 @@ class Visualizer extends Component {
                         toolPathModelGroup={this.props.toolPathModelGroup.object}
                         printableArea={this.printableArea}
                         cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
+                        cameraInitialTarget={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
                         onSelectModel={this.actions.onSelectModel}
                         onUnselectAllModels={this.actions.onUnselectAllModels}
                         onModelAfterTransform={this.actions.onModelAfterTransform}

--- a/src/app/widgets/PrintingVisualizer/PrintableCube.jsx
+++ b/src/app/widgets/PrintingVisualizer/PrintableCube.jsx
@@ -3,11 +3,15 @@ import {
     PlaneGeometry, MeshBasicMaterial, Mesh,
     TextureLoader
 } from 'three';
-import RectangleHelper from '../../components/three-extensions/RectangleHelper';
-import RectangleGridHelper from '../../components/three-extensions/RectangleGridHelper';
+import Rectangle from '../../three-extensions/objects/Rectangle';
+import Grid from '../../three-extensions/objects/Grid';
+// import RectangleHelper from '../../components/three-extensions/RectangleHelper';
+// import RectangleGridHelper from '../../components/three-extensions/RectangleGridHelper';
 
 
 class PrintableCube extends Object3D {
+    size = { x: 0, y: 0 };
+
     constructor(size) {
         super();
         this.type = 'PrintCube';
@@ -27,34 +31,22 @@ class PrintableCube extends Object3D {
 
     _setup() {
         // Faces
-        const bottom = new RectangleGridHelper(this.size.x, this.size.y, 10);
+        const bottom = Grid.createGrid(this.size.x, this.size.y, 10);
         bottom.position.set(0, 0, 0);
-        bottom.rotation.x = Math.PI; // flip to show left bottom point as zero
         this.add(bottom);
 
-        const top = new RectangleHelper(this.size.x, this.size.y);
-        top.position.set(0, this.size.z, 0);
+        const top = Rectangle.createRectangle(this.size.x, this.size.y);
+        top.position.set(0, 0, this.size.z);
         this.add(top);
 
-        const left = new RectangleHelper(this.size.z, this.size.y);
-        left.rotateZ(Math.PI / 2);
-        left.position.set(-this.size.x / 2, this.size.z / 2, 0);
+        const left = Rectangle.createRectangle(this.size.z, this.size.y);
+        left.rotateY(-Math.PI / 2);
+        left.position.set(-this.size.x / 2, 0, this.size.z / 2);
         this.add(left);
 
-        const right = new RectangleHelper(this.size.z, this.size.y);
-        right.rotateZ(Math.PI / 2);
-        right.position.set(this.size.x / 2, this.size.z / 2, 0);
+        const right = left.clone();
+        right.position.set(this.size.x / 2, 0, this.size.z / 2);
         this.add(right);
-
-        const front = new RectangleHelper(this.size.x, this.size.z);
-        front.rotateX(Math.PI / 2);
-        front.position.set(0, this.size.z / 2, this.size.y / 2);
-        this.add(front);
-
-        const back = new RectangleHelper(this.size.x, this.size.z);
-        back.rotateX(Math.PI / 2);
-        back.position.set(0, this.size.z / 2, -this.size.y / 2);
-        this.add(back);
 
         // Add logo
         const minSideLength = Math.min(this.size.x, this.size.y);
@@ -67,8 +59,7 @@ class PrintableCube extends Object3D {
             transparent: true
         });
         const mesh = new Mesh(geometry, material);
-        mesh.rotateX(-Math.PI / 2);
-        mesh.position.set(0, 0, this.size.y / 4);
+        mesh.position.set(0, -this.size.y / 4, 0);
         this.add(mesh);
     }
 }

--- a/src/app/widgets/PrintingVisualizer/Visualizer.jsx
+++ b/src/app/widgets/PrintingVisualizer/Visualizer.jsx
@@ -91,7 +91,7 @@ class Visualizer extends PureComponent {
         },
         // context menu
         centerSelectedModel: () => {
-            this.props.updateSelectedModelTransformation({ positionX: 0, positionZ: 0 });
+            this.props.updateSelectedModelTransformation({ positionX: 0, positionY: 0 });
             this.props.onModelAfterTransform();
         },
         deleteSelectedModel: () => {
@@ -171,12 +171,13 @@ class Visualizer extends PureComponent {
             const { modelGroup, gcodeLineGroup } = this.props;
 
             modelGroup.updateBoundingBox(new Box3(
-                new Vector3(-size.x / 2 - EPSILON, -EPSILON, -size.y / 2 - EPSILON),
-                new Vector3(size.x / 2 + EPSILON, size.z + EPSILON, size.y / 2 + EPSILON)
+                new Vector3(-size.x / 2 - EPSILON, -size.y / 2 - EPSILON, -EPSILON),
+                new Vector3(size.x / 2 + EPSILON, size.y / 2 + EPSILON, size.z + EPSILON)
             ));
 
-            gcodeLineGroup.position.set(-size.x / 2, 0, size.y / 2);
-            this.canvas.current.setCamera(new Vector3(0, size.z / 2, Math.max(size.x, size.y, size.z) * 2), new Vector3(0, size.z / 2, 0));
+            // Re-position model group
+            gcodeLineGroup.position.set(-size.x / 2, -size.y / 2, 0);
+            this.canvas.current.setCamera(new Vector3(0, -Math.max(size.x, size.y, size.z) * 2, size.z / 2), new Vector3(0, 0, size.z / 2));
         }
 
         if (renderingTimestamp !== this.props.renderingTimestamp) {
@@ -266,7 +267,9 @@ class Visualizer extends PureComponent {
                         size={size}
                         modelGroup={modelGroup.object}
                         printableArea={this.printableArea}
-                        cameraInitialPosition={new Vector3(0, size.z / 2, Math.max(size.x, size.y, size.z) * 2)}
+                        cameraInitialPosition={new Vector3(0, -Math.max(size.x, size.y, size.z) * 2, size.z / 2)}
+                        cameraInitialTarget={new Vector3(0, 0, size.z / 2)}
+                        cameraUp={new Vector3(0, 0, 1)}
                         gcodeLineGroup={gcodeLineGroup}
                         onSelectModel={this.actions.onSelectModel}
                         onUnselectAllModels={this.actions.onUnselectAllModels}

--- a/src/app/widgets/PrintingVisualizer/VisualizerModelTransformation.jsx
+++ b/src/app/widgets/PrintingVisualizer/VisualizerModelTransformation.jsx
@@ -20,7 +20,7 @@ class VisualizerModelTransformation extends PureComponent {
         transformMode: PropTypes.string.isRequired,
         transformation: PropTypes.shape({
             positionX: PropTypes.number,
-            positionZ: PropTypes.number,
+            positionY: PropTypes.number,
             rotationX: PropTypes.number,
             rotationY: PropTypes.number,
             rotationZ: PropTypes.number,
@@ -43,9 +43,9 @@ class VisualizerModelTransformation extends PureComponent {
                     value = Math.min(Math.max(value, -size.x / 2), size.x / 2);
                     transformation.positionX = value;
                     break;
-                case 'moveZ':
-                    value = Math.min(Math.max(value, -size.z / 2), size.z / 2);
-                    transformation.positionZ = value;
+                case 'moveY':
+                    value = Math.min(Math.max(value, -size.y / 2), size.y / 2);
+                    transformation.positionY = value;
                     break;
                 case 'scaleX':
                     transformation.scaleX = value;
@@ -81,10 +81,10 @@ class VisualizerModelTransformation extends PureComponent {
     render() {
         const actions = this.actions;
         const { size, selectedModelID, hasModel, transformMode } = this.props;
-        const { positionX, positionZ, rotationX, rotationY, rotationZ, scaleX, scaleY, scaleZ } = this.props.transformation;
+        const { positionX, positionY, rotationX, rotationY, rotationZ, scaleX, scaleY, scaleZ } = this.props.transformation;
         const disabled = !(selectedModelID && hasModel);
         const moveX = Number(toFixed(positionX, 1));
-        const moveZ = Number(toFixed(positionZ, 1));
+        const moveY = Number(toFixed(positionY, 1));
         const scaleXPercent = Number(toFixed((scaleX * 100), 1));
         const scaleYPercent = Number(toFixed((scaleY * 100), 1));
         const scaleZPercent = Number(toFixed((scaleZ * 100), 1));
@@ -182,9 +182,9 @@ class VisualizerModelTransformation extends PureComponent {
                                 <Input
                                     min={-size.y / 2}
                                     max={size.y / 2}
-                                    value={moveZ}
+                                    value={moveY}
                                     onChange={(value) => {
-                                        actions.onModelTransform('moveZ', value);
+                                        actions.onModelTransform('moveY', value);
                                         actions.onModelAfterTransform();
                                     }}
                                 />
@@ -199,12 +199,12 @@ class VisualizerModelTransformation extends PureComponent {
                                     trackStyle={{
                                         backgroundColor: '#e9e9e9'
                                     }}
-                                    value={moveZ}
+                                    value={moveY}
                                     min={-size.y / 2}
                                     max={size.y / 2}
                                     step={0.1}
                                     onChange={(value) => {
-                                        actions.onModelTransform('moveZ', value);
+                                        actions.onModelTransform('moveY', value);
                                     }}
                                     onAfterChange={() => {
                                         actions.onModelAfterTransform();
@@ -231,13 +231,13 @@ class VisualizerModelTransformation extends PureComponent {
                             <span className={styles['axis-unit-2']}>%</span>
                         </div>
                         <div className={styles.axis}>
-                            <span className={classNames(styles['axis-label'], styles['axis-blue'])}>Y</span>
+                            <span className={classNames(styles['axis-label'], styles['axis-green'])}>Y</span>
                             <span className={styles['axis-input-1']}>
                                 <Input
                                     min={0}
-                                    value={scaleZPercent}
+                                    value={scaleYPercent}
                                     onChange={(value) => {
-                                        actions.onModelTransform('scaleZ', value / 100);
+                                        actions.onModelTransform('scaleY', value / 100);
                                         actions.onModelAfterTransform();
                                     }}
                                 />
@@ -245,13 +245,13 @@ class VisualizerModelTransformation extends PureComponent {
                             <span className={styles['axis-unit-2']}>%</span>
                         </div>
                         <div className={styles.axis}>
-                            <span className={classNames(styles['axis-label'], styles['axis-green'])}>Z</span>
+                            <span className={classNames(styles['axis-label'], styles['axis-blue'])}>Z</span>
                             <span className={styles['axis-input-1']}>
                                 <Input
                                     min={0}
-                                    value={scaleYPercent}
+                                    value={scaleZPercent}
                                     onChange={(value) => {
-                                        actions.onModelTransform('scaleY', value / 100);
+                                        actions.onModelTransform('scaleZ', value / 100);
                                         actions.onModelAfterTransform();
                                     }}
                                 />
@@ -304,9 +304,9 @@ class VisualizerModelTransformation extends PureComponent {
                                 <Input
                                     min={-180}
                                     max={180}
-                                    value={rotateZ}
+                                    value={rotateY}
                                     onChange={(degree) => {
-                                        actions.onModelTransform('rotateZ', THREE.Math.degToRad(degree));
+                                        actions.onModelTransform('rotateY', THREE.Math.degToRad(degree));
                                         actions.onModelAfterTransform();
                                     }}
                                 />
@@ -321,12 +321,12 @@ class VisualizerModelTransformation extends PureComponent {
                                     trackStyle={{
                                         backgroundColor: '#e9e9e9'
                                     }}
-                                    value={rotateZ}
+                                    value={rotateY}
                                     min={-180}
                                     max={180}
                                     step={0.1}
                                     onChange={(degree) => {
-                                        actions.onModelTransform('rotateZ', THREE.Math.degToRad(degree));
+                                        actions.onModelTransform('rotateY', THREE.Math.degToRad(degree));
                                     }}
                                     onAfterChange={() => {
                                         actions.onModelAfterTransform();
@@ -340,9 +340,9 @@ class VisualizerModelTransformation extends PureComponent {
                                 <Input
                                     min={-180}
                                     max={180}
-                                    value={rotateY}
+                                    value={rotateZ}
                                     onChange={(degree) => {
-                                        actions.onModelTransform('rotateY', THREE.Math.degToRad(degree));
+                                        actions.onModelTransform('rotateZ', THREE.Math.degToRad(degree));
                                         actions.onModelAfterTransform();
                                     }}
                                 />
@@ -357,12 +357,12 @@ class VisualizerModelTransformation extends PureComponent {
                                     trackStyle={{
                                         backgroundColor: '#e9e9e9'
                                     }}
-                                    value={rotateY}
+                                    value={rotateZ}
                                     min={-180}
                                     max={180}
                                     step={0.1}
                                     onChange={(degree) => {
-                                        actions.onModelTransform('rotateY', THREE.Math.degToRad(degree));
+                                        actions.onModelTransform('rotateZ', THREE.Math.degToRad(degree));
                                     }}
                                     onAfterChange={() => {
                                         actions.onModelAfterTransform();

--- a/src/app/widgets/WorkspaceVisualizer/Visualizer.jsx
+++ b/src/app/widgets/WorkspaceVisualizer/Visualizer.jsx
@@ -682,6 +682,7 @@ class Visualizer extends Component {
                         modelGroup={this.visualizerGroup}
                         printableArea={this.printableArea}
                         cameraInitialPosition={new THREE.Vector3(0, 0, Math.min(this.props.size.z * 2, 300))}
+                        cameraInitialTarget={new THREE.Vector3(0, 0, 0)}
                     />
                 </div>
                 <div className={styles['canvas-footer']}>

--- a/src/app/workers/GcodeToBufferGeometry/GcodeToBufferGeometryPrint3d.js
+++ b/src/app/workers/GcodeToBufferGeometry/GcodeToBufferGeometryPrint3d.js
@@ -111,8 +111,8 @@ class GcodeToBufferGeometryPrint3d {
                 }
 
                 positions.push(v2.x);
+                positions.push(v2.y);
                 positions.push(v2.z);
-                positions.push(-v2.y);
 
                 colors.push(rgb[0]);
                 colors.push(rgb[1]);

--- a/src/app/workers/LoadModel.worker.js
+++ b/src/app/workers/LoadModel.worker.js
@@ -10,7 +10,7 @@ onmessage = (e) => {
         uploadPath,
         (geometry) => {
             // Rotate x by 90 degrees
-            geometry.rotateX(-Math.PI / 2);
+            // geometry.rotateX(-Math.PI / 2);
 
             // Translate model by x:[-a, a]  z:[-b, b]  y:[-c, c], which center the model at zero
             geometry.computeBoundingBox();


### PR DESCRIPTION
Refactor three.js code to make XYZ directions the as natural directions.

Things changed as below:

- General
    - 3D model loader
    - 3D model exporter (mainly for generating G-code)
- In 3DP G-code generator:
    - Actions on bottom bar: toLeft, toRight, toTop, toBottom
    - Camera initial position and target position, and camera up vector (different than three.js defaults to Y positive direction)
    - Controls: the way camera orbits around target position
    - TransformControl (3D): update control geometry
    - Print area model (PrintingCube)
    - Lay Flat function
    - Check model boundary
    - G-code rendering (WebWorker)
- Canvas compatibilities for Workspace, Laser, CNC generators

