### PR TITLE
Build: Build br for v3.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "snapmaker-luban",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapmaker-luban",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "A web-based interface for Snapmaker 3-in-1 3D Printer",
   "homepage": "https://github.com/whimsycwd/Snapmakerjs",
   "author": "Snapmaker Dev Team <whimsycwd@snapmaker.com>",

--- a/src/app/widgets/CNCVisualizer/styles.styl
+++ b/src/app/widgets/CNCVisualizer/styles.styl
@@ -201,7 +201,7 @@ button:focus
         width: 56px
         height: 56px
         padding: 0
-        border: none
+        border: 0
 
         .btn-text
             height: 100%

--- a/src/app/widgets/CncLaserObjectList/styles.styl
+++ b/src/app/widgets/CncLaserObjectList/styles.styl
@@ -47,8 +47,8 @@
     &.icon-hide-open
         background: url("./images/list_ic_open_18x18@2x.png") no-repeat center center
         margin-left: 8px
-        border: none
+        border: 0
     &.icon-hide-close
         background: url("./images/list_ic_close_18x18@2x.png") no-repeat center center
         margin-left: 8px
-        border: none
+        border: 0

--- a/src/app/widgets/CncLaserSvgEditor/index.styl
+++ b/src/app/widgets/CncLaserSvgEditor/index.styl
@@ -72,7 +72,7 @@ $padding = 10px
             width: 56px
             height: 56px
             padding: 0
-            border: none
+            border: 0
             background-color: $background-color
 
             &.selected

--- a/src/app/widgets/LaserVisualizer/styles.styl
+++ b/src/app/widgets/LaserVisualizer/styles.styl
@@ -197,7 +197,7 @@ $visualizer-padding = 10px
         width: 56px
         height: 56px
         padding: 0
-        border: none
+        border: 0
 
         .btn-text
             height: 100%

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapmaker-luban",
-  "version": "3.6.1",
+  "version": "3.7.0",
   "description": "Snapmaker 3-in-1 Software for 3D Printing, Laser Engraving and CNC Cutting.",
   "homepage": "https://github.com/whimsycwd/Snapmakerjs",
   "author": "Snapmaker Dev Team <whimsycwd@snapmaker.com>",

--- a/src/server/lib/ToolPathGenerator/LaserToolPathGenerator.js
+++ b/src/server/lib/ToolPathGenerator/LaserToolPathGenerator.js
@@ -449,7 +449,7 @@ class LaserToolPathGenerator extends EventEmitter {
             x: targetWidth / originWidth,
             y: targetHeight / originHeight
         });
-        if (optimizePath) {
+        if (optimizePath && svg.shapes.left < 2000) {
             sortShapes(svg);
         }
         rotate(svg, rotationZ); // rotate: unit is radians and counter-clockwise

--- a/src/server/slicer/slice.js
+++ b/src/server/slicer/slice.js
@@ -56,7 +56,7 @@ function processGcodeHeaderAfterCuraEngine(gcodeFilePath, boundingBox, thumbnail
         + `;thumbnail: ${thumbnail}\n`
         + `;file_total_lines: ${readFileSync.split('\n').length + 20}\n`
         + `;estimated_time(s): ${printTime}\n`
-        + `;nozzle_temperature(°C): ${definitionLoader.settings.material_print_temperature.default_value}\n`
+        + `;nozzle_temperature(°C): ${definitionLoader.settings.material_print_temperature_layer_0.default_value}\n`
         + `;build_plate_temperature(°C): ${definitionLoader.settings.material_bed_temperature_layer_0.default_value}\n`
         + `;work_speed(mm/minute): ${definitionLoader.settings.speed_infill.default_value * 60}\n`
         + `;max_x(mm): ${boundingBoxMax.x}\n`


### PR DESCRIPTION
- Use material_print_temperature_layer_0 instead of material_print_temperature in the gcode header
- Don`t use optimizePath when svg shapes length > 2000