### PR TITLE
Fix: Fix SVG numeric parsing

### DIFF
--- a/src/shared/lib/SVGParser/AttributesParser.js
+++ b/src/shared/lib/SVGParser/AttributesParser.js
@@ -8,7 +8,9 @@ const log = logger('SVGParser:AttributesParser');
 function parseDAttribute(value) {
     const items = [];
 
-    const re = /([A-Za-z]|(-?\.?[0-9]+\.?[0-9]*(e-?[0-9]*)?))/g;
+    // const re = /([A-Za-z]|(-?\.?[0-9]+\.?[0-9]*(e-?[0-9]*)?))/g;
+    // https://www.regular-expressions.info/floatingpoint.html
+    const re = /([A-Za-z]|([+-]?[0-9]*\.?[0-9]+([Ee][+-]?[0-9]+)?))/g;
     let m = re.exec(value);
     while (m) {
         const f = parseFloat(m[1]);


### PR DESCRIPTION
`a.76.76,0,0,0` was parsed into [a, 0.76, 0, 0, 0] in previous implementation, results in number of tokens are not aligned, the shape is missing from parse result.

With coding changes, `a.76.76,0,0,0` should be parsed as  [a, 0.76, 0.76, 0, 0, 0].


Sample:
```SVG
<svg id="图层_1" data-name="图层 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 737.01 963.78">
  <rect class="cls-1" width="737.01" height="963.78"/>
  <path class="cls-1" d="M67.63,259.62a.76.76,0,0,0,.08.32,1.06,1.06,0,0,1,.08.49l-24,24q.5,4.38.9,9.16t.4,7.7q0,5.34-.16,13.53t-.49,19.37q1,15.88,2.43,29.59t3.25,23.9a157.58,157.58,0,0,0,8.59,29.75,87.15,87.15,0,0,0,12.64,22,51.08,51.08,0,0,0,16.53,13.7,44.45,44.45,0,0,0,20.43,4.7,62,62,0,0,0,40-14.26c.86-.76,1.72-1.49,2.59-2.19s1.73-1.49,2.59-2.35l9.24-9.4a62.19,62.19,0,0,0,4.3,7A71.7,71.7,0,0,0,172,443a47.89,47.89,0,0,0,15.16,11.1,43,43,0,0,0,18.07,3.81,47.24,47.24,0,0,0,18.89-3.81,51.15,51.15,0,0,0,16-10.94l19.29-19.45a51.49,51.49,0,0,0,5.11-4.46q2.34-2.35,4.62-5.1a73.28,73.28,0,0,0,11.34-21.24,75.72,75.72,0,0,0,3.89-24.47l3.25-107.31Z"/>
</svg>
```