### PR TITLE
Improvement: convert svg's component paths one at a time

### DIFF
--- a/src/server/lib/ToolPathGenerator/SVGFill.js
+++ b/src/server/lib/ToolPathGenerator/SVGFill.js
@@ -174,13 +174,14 @@ function svgToSegments(svg, options = {}) {
         const color = 1; // only black & white, use 1 to mark canvas as painted
         const width = Math.round(options.width * options.fillDensity);
         const height = Math.round(options.height * options.fillDensity);
-
-        const canvas = new Array(width);
-        for (let i = 0; i < width; i++) {
-            canvas[i] = new Uint8Array(height);
-        }
+        let out = [];
 
         for (const shape of svg.shapes) {
+            const canvas = new Array(width);
+            for (let i = 0; i < width; i++) {
+                canvas[i] = new Uint8Array(height);
+            }
+
             if (!shape.visibility) {
                 continue;
             }
@@ -210,9 +211,11 @@ function svgToSegments(svg, options = {}) {
                 }
                 fillShape(canvas, width, height, newShape, color);
             }
+
+            out = [...out, ...canvasToSegments(canvas, width, height, options.fillDensity)];
         }
 
-        return canvasToSegments(canvas, width, height, options.fillDensity);
+        return out;
     }
 }
 

--- a/src/server/lib/ToolPathGenerator/SVGFill.js
+++ b/src/server/lib/ToolPathGenerator/SVGFill.js
@@ -175,6 +175,10 @@ function svgToSegments(svg, options = {}) {
         const width = Math.round(options.width * options.fillDensity);
         const height = Math.round(options.height * options.fillDensity);
         let out = [];
+        const accumulatorCanvas = new Array(width);
+        for (let i = 0; i < width; i++) {
+            accumulatorCanvas[i] = new Uint8Array(height);
+        }
 
         for (const shape of svg.shapes) {
             const canvas = new Array(width);
@@ -211,7 +215,14 @@ function svgToSegments(svg, options = {}) {
                 }
                 fillShape(canvas, width, height, newShape, color);
             }
-
+            canvas.map((row, rowIndex) => row.map((value, columnIndex) => {
+                if (value && !accumulatorCanvas[rowIndex][columnIndex]) {
+                    accumulatorCanvas[rowIndex][columnIndex] = value;
+                    return value;
+                } else {
+                    return 0; // prevent the same canvas section being painted twice
+                }
+            }));
             out = [...out, ...canvasToSegments(canvas, width, height, options.fillDensity)];
         }
 

--- a/src/server/lib/ToolPathGenerator/SVGFill.js
+++ b/src/server/lib/ToolPathGenerator/SVGFill.js
@@ -215,14 +215,16 @@ function svgToSegments(svg, options = {}) {
                 }
                 fillShape(canvas, width, height, newShape, color);
             }
-            canvas.map((row, rowIndex) => row.map((value, columnIndex) => {
-                if (value && !accumulatorCanvas[rowIndex][columnIndex]) {
-                    accumulatorCanvas[rowIndex][columnIndex] = value;
-                    return value;
-                } else {
-                    return 0; // prevent the same canvas section being painted twice
+            for (const [row, rowIndex] of canvas.entries()) {
+                for (const [value, columnIndex] of row.entries()) {
+                    if (accumulatorCanvas[rowIndex][columnIndex]) {
+                        canvas[rowIndex][columnIndex] = 0;
+                    }
+                    if (value) {
+                        accumulatorCanvas[rowIndex][columnIndex] = value;
+                    }
                 }
-            }));
+            }
             out = [...out, ...canvasToSegments(canvas, width, height, options.fillDensity)];
         }
 

--- a/src/server/lib/ToolPathGenerator/SVGFill.js
+++ b/src/server/lib/ToolPathGenerator/SVGFill.js
@@ -215,8 +215,8 @@ function svgToSegments(svg, options = {}) {
                 }
                 fillShape(canvas, width, height, newShape, color);
             }
-            for (const [row, rowIndex] of canvas.entries()) {
-                for (const [value, columnIndex] of row.entries()) {
+            for (const [rowIndex, row] of canvas.entries()) {
+                for (const [columnIndex, value] of row.entries()) {
                     if (accumulatorCanvas[rowIndex][columnIndex]) {
                         canvas[rowIndex][columnIndex] = 0;
                     }


### PR DESCRIPTION
This changes svg filling to generate segments per path in the svg this can greatly reduce the amount of time the head spends jogging for svgs containing many non overlapping spaced apart shapes. I have attached an example svg in this zip to demonstrate the improvement.

[example.zip](https://github.com/Snapmaker/Luban/files/5329757/example.zip)
