### PR TITLE
Fix: Need to check that "ports" is empty or not when disconnect from Wi-FI

### DIFF
--- a/src/app/flux/machine/index.js
+++ b/src/app/flux/machine/index.js
@@ -683,14 +683,14 @@ export const actions = {
     },
 
     close: (options, isEmergencyStopped) => (dispatch, getState) => {
-        const { port } = options;
         const state = getState().machine;
         const ports = [...state.ports];
-        const portIndex = ports.indexOf(port);
-        if (portIndex !== -1) {
-            ports.splice(portIndex, 1);
-        }
         if (!isEmpty(ports)) {
+            const { port } = options;
+            const portIndex = ports.indexOf(port);
+            if (portIndex !== -1) {
+                ports.splice(portIndex, 1);
+            }
             // this.port = ports[0];
             dispatch(baseActions.updateState({
                 port: ports[0],

--- a/src/app/flux/machine/index.js
+++ b/src/app/flux/machine/index.js
@@ -585,7 +585,9 @@ export const actions = {
                     isEmergencyStopped
                 } = result.data;
                 if (isEmergencyStopped) {
-                    dispatch(actions.close(null, true));
+                    dispatch(baseActions.updateState({
+                        isEmergencyStopped
+                    }));
                     server.close(() => {
                         dispatch(actions.resetMachineState());
                     });


### PR DESCRIPTION
It causes the machine not to disconnect from Wi-Fi when the machine is in "emergency stop" state.