### PR TITLE
Perf: Improve memory usage of big files in 3dp

### DIFF
--- a/src/app/components/three-extensions/STLBinaryExporter.js
+++ b/src/app/components/three-extensions/STLBinaryExporter.js
@@ -1,6 +1,6 @@
-/* eslint-disable */
+/* eslint-disable func-names */
 
-import * as THREE from "three";
+import * as THREE from 'three';
 
 /**
  * @author kovacsv / http://kovacsv.hu/
@@ -12,96 +12,172 @@ import * as THREE from "three";
  * 2. Switch y and z (line 87) to handle left-hand and right-hand coordinate problem
  */
 
-function STLBinaryExporter() {};
+function STLBinaryExporter() {}
 
 STLBinaryExporter.prototype = {
 
-	constructor: STLBinaryExporter,
+    constructor: STLBinaryExporter,
 
-	parse: ( function () {
+    parse: (function () {
+        const vector = new THREE.Vector3();
+        const normalMatrixWorld = new THREE.Matrix3();
 
-		var vector = new THREE.Vector3();
-		var normalMatrixWorld = new THREE.Matrix3();
+        return function parse(scene) {
+            if (scene.isMesh && scene.geometry.isBufferGeometry && scene.children.length === 0) {
+                return this._parseBufferGeometryMeshWithoutChildren(scene);
+            }
 
-		return function parse( scene ) {
+            // We collect objects first, as we may need to convert from BufferGeometry to Geometry
+            const objects = [];
+            let triangles = 0;
+            scene.traverse((object) => {
+                if (!(object instanceof THREE.Mesh)) return;
 
-			// We collect objects first, as we may need to convert from BufferGeometry to Geometry
-			var objects = [];
-			var triangles = 0;
-			scene.traverse( function ( object ) {
+                let geometry = object.geometry;
+                if (geometry instanceof THREE.BufferGeometry) {
+                    geometry = new THREE.Geometry().fromBufferGeometry(geometry);
+                }
 
-				if ( ! ( object instanceof THREE.Mesh ) ) return;
-
-				var geometry = object.geometry;
-				if ( geometry instanceof THREE.BufferGeometry ) {
-
-					geometry = new THREE.Geometry().fromBufferGeometry( geometry );
-
-				}
-
-				if ( ! ( geometry instanceof THREE.Geometry ) ) return;
-				triangles += geometry.faces.length;
+                if (!(geometry instanceof THREE.Geometry)) return;
+                triangles += geometry.faces.length;
 
                 object.updateMatrixWorld();
 
-				objects.push( {
+                objects.push({
 
-					geometry: geometry,
+                    geometry: geometry,
                     matrix: object.matrixWorld
-					// matrix: object.matrix
+                    // matrix: object.matrix
 
-				} );
+                });
+            });
 
-			} );
+            let offset = 80; // skip header
+            const bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
+            const arrayBuffer = new ArrayBuffer(bufferLength);
+            const output = new DataView(arrayBuffer);
+            output.setUint32(offset, triangles, true); offset += 4;
 
-			var offset = 80; // skip header
-			var bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
-			var arrayBuffer = new ArrayBuffer( bufferLength );
-			var output = new DataView( arrayBuffer );
-			output.setUint32( offset, triangles, true ); offset += 4;
+            // Traversing our collected objects
+            objects.forEach((object) => {
+                const vertices = object.geometry.vertices;
+                const faces = object.geometry.faces;
 
-			// Traversing our collected objects
-			objects.forEach( function ( object ) {
+                normalMatrixWorld.getNormalMatrix(object.matrix);
 
-				var vertices = object.geometry.vertices;
-				var faces = object.geometry.faces;
+                for (let i = 0, l = faces.length; i < l; i++) {
+                    const face = faces[i];
 
-				normalMatrixWorld.getNormalMatrix( object.matrix );
+                    vector.copy(face.normal).applyMatrix3(normalMatrixWorld).normalize();
 
-				for ( var i = 0, l = faces.length; i < l; i ++ ) {
+                    output.setFloat32(offset, vector.x, true); offset += 4; // normal
+                    output.setFloat32(offset, vector.y, true); offset += 4;
+                    output.setFloat32(offset, vector.z, true); offset += 4;
 
-					var face = faces[ i ];
+                    const indices = [face.a, face.b, face.c];
 
-					vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
+                    for (let j = 0; j < 3; j++) {
+                        vector.copy(vertices[indices[j]]).applyMatrix4(object.matrix);
 
-					output.setFloat32( offset, vector.x, true ); offset += 4; // normal
-					output.setFloat32( offset, vector.y, true ); offset += 4;
-					output.setFloat32( offset, vector.z, true ); offset += 4;
+                        output.setFloat32(offset, vector.x, true); offset += 4; // vertices
+                        output.setFloat32(offset, vector.y, true); offset += 4;
+                        output.setFloat32(offset, vector.z, true); offset += 4;
+                    }
 
-					var indices = [ face.a, face.b, face.c ];
+                    output.setUint16(offset, 0, true); offset += 2; // attribute byte count
+                }
+            });
 
-					for ( var j = 0; j < 3; j ++ ) {
+            return output;
+        };
+    }()),
 
-						vector.copy( vertices[ indices[ j ] ] ).applyMatrix4( object.matrix );
+    _parseBufferGeometryMeshWithoutChildren: (function () {
+        const vA = new THREE.Vector3();
+        const vB = new THREE.Vector3();
+        const vC = new THREE.Vector3();
+        const cb = new THREE.Vector3(), ab = new THREE.Vector3();
+        const vector = new THREE.Vector3();
+        const normalMatrixWorld = new THREE.Matrix3();
 
-						output.setFloat32( offset, vector.x, true ); offset += 4; // vertices
-						output.setFloat32( offset, vector.y, true ); offset += 4;
-						output.setFloat32( offset, vector.z, true ); offset += 4;
+        // parse directly from buffer geometry, inspired by:
+        // https://github.com/mrdoob/three.js/blob/ba4489ded66212ac9e6d3017a6bb856023bd026f/src/core/Geometry.js#L290
+        return function parse(object) {
+            const attributes = object.geometry.attributes;
+            const positions = attributes.position.array;
+            const groups = object.geometry.groups;
+            const indices = object.geometry.index !== null ? object.geometry.index.array : undefined;
+            normalMatrixWorld.getNormalMatrix(object.matrix);
 
-					}
+            let offset = 80; // skip header
+            const triangles = positions.length / 9;
+            const bufferLength = triangles * 2 + triangles * 3 * 4 * 4 + 80 + 4;
+            const arrayBuffer = new ArrayBuffer(bufferLength);
+            const output = new DataView(arrayBuffer);
+            output.setUint32(offset, triangles, true); offset += 4;
 
-					output.setUint16( offset, 0, true ); offset += 2; // attribute byte count
 
-				}
+            const addFace = (a, b, c) => {
+                // compute face normal
+                // https://github.com/mrdoob/three.js/blob/ba4489ded66212ac9e6d3017a6bb856023bd026f/src/core/BufferGeometry.js#L726
+                vA.set(positions[a * 3], positions[a * 3 + 1], positions[a * 3 + 2]);
+                vB.set(positions[b * 3], positions[b * 3 + 1], positions[b * 3 + 2]);
+                vC.set(positions[c * 3], positions[c * 3 + 1], positions[c * 3 + 2]);
+                cb.subVectors(vC, vB);
+                ab.subVectors(vA, vB);
+                cb.cross(ab);
+                cb.normalize();
 
-			} );
+                vector.copy(cb).applyMatrix3(normalMatrixWorld).normalize();
 
-			return output;
+                output.setFloat32(offset, vector.x, true); offset += 4; // normal
+                output.setFloat32(offset, vector.y, true); offset += 4;
+                output.setFloat32(offset, vector.z, true); offset += 4;
 
-		};
+                const vertices = [vA, vB, vC];
 
-	}() )
+                for (let j = 0; j < 3; j++) {
+                    vector.copy(vertices[j]).applyMatrix4(object.matrix);
 
+                    output.setFloat32(offset, vector.x, true); offset += 4; // vertices
+                    output.setFloat32(offset, vector.y, true); offset += 4;
+                    output.setFloat32(offset, vector.z, true); offset += 4;
+                }
+
+                output.setUint16(offset, 0, true); offset += 2; // attribute byte count
+            };
+
+            if (groups.length > 0) {
+                for (let i = 0; i < groups.length; i++) {
+                    const group = groups[i];
+
+                    const start = group.start;
+                    const count = group.count;
+
+                    for (let j = start, jl = start + count; j < jl; j += 3) {
+                        if (indices !== undefined) {
+                            addFace(indices[j], indices[j + 1], indices[j + 2]);
+                        } else {
+                            addFace(j, j + 1, j + 2);
+                        }
+                    }
+                }
+            } else {
+                if (indices !== undefined) {
+                    for (let i = 0; i < indices.length; i += 3) {
+                        addFace(indices[i], indices[i + 1], indices[i + 2]);
+                    }
+                } else {
+                    for (let i = 0; i < positions.length / 3; i += 3) {
+                        addFace(i, i + 1, i + 2);
+                    }
+                }
+            }
+
+
+            return output;
+        };
+    }())
 };
 
 export default STLBinaryExporter;

--- a/src/app/components/three-extensions/STLLoader.js
+++ b/src/app/components/three-extensions/STLLoader.js
@@ -104,6 +104,7 @@ STLLoader.prototype = {
 
 		}
 
+        // TODO: loading file over 480M will crash because of memory limit
 		function parseBinary( data, onProgress ) {
 			var reader = new DataView( data );
 			var faces = reader.getUint32( 80, true );

--- a/src/app/flux/printing/index.js
+++ b/src/app/flux/printing/index.js
@@ -133,6 +133,43 @@ const ACTION_UPDATE_TRANSFORMATION = 'printing/ACTION_UPDATE_TRANSFORMATION';
 // TODO: invest worker thread memory costs
 const gcodeRenderingWorker = new GcodeToBufferGeometryWorker();
 
+// avoid parallel loading of same file
+const createLoadModelWorker = (() => {
+    const runningTasks = {};
+    return (uploadPath, onMessage) => {
+        let task = runningTasks[uploadPath];
+        if (!task) {
+            task = {
+                worker: new LoadModelWorker(),
+                cbOnMessage: []
+            };
+            task.worker.postMessage({ uploadPath });
+            task.worker.onmessage = async (e) => {
+                const data = e.data;
+                const { type } = data;
+
+                switch (type) {
+                    case 'LOAD_MODEL_CONVEX':
+                    case 'LOAD_MODEL_FAILED':
+                        task.worker.terminate();
+                        delete runningTasks[uploadPath];
+                        break;
+                    default:
+                        break;
+                }
+                for (const fn of task.cbOnMessage) {
+                    if (typeof fn === 'function') {
+                        fn(e);
+                    }
+                }
+            };
+            runningTasks[uploadPath] = task;
+        }
+
+        task.cbOnMessage.push(onMessage);
+    };
+})();
+
 export const actions = {
     updateState: (state) => {
         return {
@@ -1180,9 +1217,8 @@ export const actions = {
         const { modelGroup } = getState().printing;
         // const sourceType = '3d';
 
-        const worker = new LoadModelWorker();
-        worker.postMessage({ uploadPath });
-        worker.onmessage = async (e) => {
+
+        const onMessage = async (e) => {
             const data = e.data;
 
             const { type } = data;
@@ -1226,7 +1262,6 @@ export const actions = {
                     break;
                 }
                 case 'LOAD_MODEL_CONVEX': {
-                    worker.terminate();
                     const { positions } = data;
 
                     const convexGeometry = new THREE.BufferGeometry();
@@ -1247,7 +1282,6 @@ export const actions = {
                     break;
                 }
                 case 'LOAD_MODEL_FAILED': {
-                    worker.terminate();
                     dispatch(actions.updateState({
                         stage: PRINTING_STAGE.LOAD_MODEL_FAILED,
                         progress: 0
@@ -1258,6 +1292,7 @@ export const actions = {
                     break;
             }
         };
+        createLoadModelWorker(uploadPath, onMessage);
     }
 };
 

--- a/src/app/models/Model.js
+++ b/src/app/models/Model.js
@@ -43,10 +43,10 @@ class Model {
 
         this.limitSize = limitSize;
 
-        const geometry = modelInfo.geometry || new THREE.PlaneGeometry(width, height);
-        const material = modelInfo.material || new THREE.MeshBasicMaterial({ color: 0xe0e0e0, visible: false });
+        this.geometry = modelInfo.geometry || new THREE.PlaneGeometry(width, height);
+        const material = modelInfo.material || new THREE.MeshPhongMaterial({ color: 0xa0a0a0, specular: 0xb0b0b0, shininess: 0 });
 
-        this.meshObject = new THREE.Mesh(geometry, material);
+        this.meshObject = new THREE.Mesh(this.geometry, material);
 
         this.modelID = modelID;
         this.modelName = modelName ?? 'unnamed';
@@ -97,6 +97,10 @@ class Model {
 
         this.lastToolPathStr = null;
         this.isToolPath = false;
+
+        if (modelInfo.convexGeometry) {
+            this.setConvexGeometry(modelInfo.convexGeometry);
+        }
     }
 
     get visible() {
@@ -571,11 +575,7 @@ class Model {
      * @returns {Model}
      */
     clone(modelGroup) {
-        const clone = new Model({
-            ...this,
-            geometry: this.meshObject.geometry.clone(),
-            material: this.meshObject.material.clone()
-        }, modelGroup);
+        const clone = new Model({ ...this }, modelGroup);
         clone.originModelID = this.modelID;
         clone.modelID = uuid.v4();
         clone.generateModelObject3D();
@@ -583,13 +583,6 @@ class Model {
         this.meshObject.updateMatrixWorld();
 
         clone.setMatrix(this.meshObject.matrixWorld);
-
-        // copy convex geometry as well
-        if (this.sourceType === '3d') {
-            if (this.convexGeometry) {
-                clone.convexGeometry = this.convexGeometry.clone();
-            }
-        }
 
         return clone;
     }
@@ -641,7 +634,7 @@ class Model {
 
     getSerializableConfig() {
         const {
-            modelID, limitSize, headType, sourceType, sourceHeight, sourceWidth, originalName, uploadName, config, mode, geometry, material,
+            modelID, limitSize, headType, sourceType, sourceHeight, sourceWidth, originalName, uploadName, config, mode,
             transformation, processImageName
         } = this;
         return {
@@ -655,8 +648,6 @@ class Model {
             uploadName,
             config,
             mode,
-            geometry,
-            material,
             transformation,
             processImageName
         };


### PR DESCRIPTION
- Do not clone Geometry and ConvexGeometry in Model.clone
- Loading only once when the same model copied in object list when
  recovery
- Do not convert BufferGeometry to Geometry when export for slice