### PR TITLE
Fix: Fix several bugs for model configuration, wrong text size and wrong tool path size

### DIFF
--- a/src/app/flux/editor/index.js
+++ b/src/app/flux/editor/index.js
@@ -555,10 +555,11 @@ export const actions = {
     // },
 
     duplicateSelectedModel: (headType) => (dispatch, getState) => {
-        const { page, modelGroup } = getState()[headType];
+        const { page, modelGroup, toolPathModelGroup } = getState()[headType];
         if (page === PAGE_PROCESS) return;
 
-        const { originalName, uploadName, config, sourceType, gcodeConfig, sourceWidth, sourceHeight, mode, transformation } = modelGroup.getSelectedModel();
+        const { originalName, uploadName, config, sourceType, sourceWidth, sourceHeight, mode, transformation } = modelGroup.getSelectedModel();
+        const { gcodeConfig } = toolPathModelGroup.getSelectedModel();
         dispatch(actions.generateModel(headType, originalName, uploadName, sourceWidth, sourceHeight, mode,
             sourceType, config, gcodeConfig, transformation));
         dispatch(actions.resetProcessState(headType));

--- a/src/app/models/SVGActionsFactory.js
+++ b/src/app/models/SVGActionsFactory.js
@@ -713,8 +713,8 @@ class SVGActionsFactory {
             width,
             height,
             transformation: {
-                width,
-                height
+                width: width * model.transformation.scaleX,
+                height: height * model.transformation.scaleY
             }
         };
         model.updateAndRefresh({ ...baseUpdateData, config });

--- a/src/server/lib/ToolPathGenerator/CncToolPathGenerator.js
+++ b/src/server/lib/ToolPathGenerator/CncToolPathGenerator.js
@@ -168,27 +168,27 @@ export default class CNCToolPathGenerator extends EventEmitter {
     }
 
     _processSVG(svg, modelInfo) {
-        const { transformation, sourceHeight, sourceType, sourceWidth, gcodeConfig, toolParams } = modelInfo;
+        const { transformation, sourceType, gcodeConfig, toolParams } = modelInfo;
 
         const { pathType = 'path', targetDepth, fillEnabled, fillDensity } = gcodeConfig;
         const { toolDiameter, toolAngle, toolShaftDiameter } = toolParams;
 
         const { scaleX, scaleY } = transformation;
 
-        const originHeight = sourceHeight;
-        const originWidth = sourceWidth;
+        const originWidth = svg.width;
+        const originHeight = svg.height;
         const targetHeight = transformation.height;
         const targetWidth = transformation.width;
 
         // rotation: degree and counter-clockwise
         const rotationZ = transformation.rotationZ;
-        const flipFlag = transformation.flip;
+        // const flipFlag = transformation.flip;
 
         if (sourceType !== 'dxf') {
             flip(svg, 1);
         }
 
-        flip(svg, flipFlag);
+        // flip(svg, flipFlag);
         scale(svg, {
             x: (scaleX > 0 ? 1 : -1) * targetWidth / originWidth,
             y: (scaleY > 0 ? 1 : -1) * targetHeight / originHeight

--- a/src/server/lib/ToolPathGenerator/LaserToolPathGenerator.js
+++ b/src/server/lib/ToolPathGenerator/LaserToolPathGenerator.js
@@ -375,8 +375,8 @@ class LaserToolPathGenerator extends EventEmitter {
         const { transformation, gcodeConfig } = modelInfo;
         const { fillEnabled, fillDensity, optimizePath } = gcodeConfig;
         const { fixedPowerEnabled, fixedPower, workSpeed, jogSpeed } = gcodeConfig;
-        const originWidth = modelInfo.sourceWidth;
-        const originHeight = modelInfo.sourceHeight;
+        const originWidth = svg.width;
+        const originHeight = svg.height;
         const targetWidth = transformation.width;
         const targetHeight = transformation.height;
 


### PR DESCRIPTION
- Fix laser/cnc toolpath size error when changing size in transformation widget
- Fix laser/cnc copied model processing config not being copied
- Fix laser/cnc scaled text toolpath size error when changing text in transformation widget
- Fix cnc toolpath flip error of svg