### PR TITLE
Fix: Reset state to "displayModel" when destroy G-code line

### DIFF
--- a/src/app/flux/printing/index.js
+++ b/src/app/flux/printing/index.js
@@ -779,7 +779,8 @@ export const actions = {
             gcodeLineGroup.remove(gcodeLine);
             gcodeLine.geometry.dispose();
             dispatch(actions.updateState({
-                gcodeLine: null
+                gcodeLine: null,
+                displayedType: 'model'
             }));
         }
     },


### PR DESCRIPTION
It causes that the time clock is not destroyed.