### PR TITLE
Improvement: Use actual checkbox for optional dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "@babel/runtime": "~7.12.0",
     "@trendmicro/react-breadcrumbs": "~0.5.4",
     "@trendmicro/react-buttons": "~1.3.0",
+    "@trendmicro/react-checkbox": "^3.4.1",
     "@trendmicro/react-dropdown": "~1.3.0",
     "@trendmicro/react-interpolate": "~0.5.3",
     "@trendmicro/react-modal": "~2.3.0",

--- a/src/app/components/Checkbox/index.js
+++ b/src/app/components/Checkbox/index.js
@@ -1,0 +1,3 @@
+import '@trendmicro/react-checkbox/dist/react-checkbox.css';
+
+export { Checkbox as default } from '@trendmicro/react-checkbox';

--- a/src/app/components/OptionalDropdown/OptionalDropdown.jsx
+++ b/src/app/components/OptionalDropdown/OptionalDropdown.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import Anchor from '../Anchor';
 import TipTrigger from '../TipTrigger';
 import styles from './styles.styl';
+import Checkbox from '../Checkbox';
 
 // TODO: to be improved
 const OptionalDropdown = (props) => {
@@ -18,8 +19,7 @@ const OptionalDropdown = (props) => {
                             onClick={onClick}
                             disabled={disabled}
                         >
-                            <i className={classNames(styles.icon, hidden ? styles['icon-unchecked'] : styles['icon-checked'])} />
-                            <span>{title}</span>
+                            <Checkbox disabled={disabled} checked={!hidden} className={styles.checkbox} label={title} />
                         </Anchor>
                     </div>
                     <div className={styles['expandable-separator']}>

--- a/src/app/components/OptionalDropdown/styles.styl
+++ b/src/app/components/OptionalDropdown/styles.styl
@@ -24,13 +24,5 @@
     .expandable-separator-inner
         margin-left: 10px
 
-.icon
-    display: inline-block
-    width: 14px
-    height: 14px
-    margin: 4px 4px -2px
-
-    &.icon-checked
-        background-image: url("../../images/checked-on-14x14.png")
-    &.icon-unchecked
-        background-image: url("../../images/checked-off-14x14.png")
+.checkbox > span 
+    margin-left: 4px !important


### PR DESCRIPTION
This fixes #829.

The UI for the optional dropdown component is pretty confusing. When it's collapsed it shows a grayed out but checked checkbox. To me, that usually means the option is selected, but not changeable. That's not really what's happening, so I updated the UI to be a little more straight forward

There's still a checkbox as before (when selected): 

<img width="376" alt="image" src="https://user-images.githubusercontent.com/3087225/110277171-be5b0e00-7fa2-11eb-80a0-3a692c98f864.png">

But now the unselected state is an empty checkbox:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/3087225/110277200-c915a300-7fa2-11eb-99a5-05a745279e2b.png">

I'll note that the above example is actually pretty weird from a UX perspective. Generally you'd use a checkbox to represent a user selection, but in the above example it's really just representing the expansion of the included panel. I didn't really dig into changing that though, just really wanted to keep it simple. 

For cases like selecting fill, multi-pass, etc from laser cutting this should be much clearer. 