### PR TITLE
Fix: Hide B axis log in console when connected by serial

### DIFF
--- a/src/server/controllers/Marlin/Marlin.js
+++ b/src/server/controllers/Marlin/Marlin.js
@@ -495,7 +495,7 @@ class MarlinParserSelectedCurrent {
 
 class MarlinParserOriginOffset {
     static parse(line) {
-        const r = line.match(/^Origin offset ([XYZ]): (.*)$/);
+        const r = line.match(/^Origin offset ([XYZB]): (.*)$/);
         if (!r) {
             return null;
         }


### PR DESCRIPTION
SB-414
