### PR TITLE
Update Development.md to include peer dependencies

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -91,10 +91,10 @@ If you want to contribute to Luban, you can follow the instructions below to set
     > cd Luban
     ```
 
-- Use `npm` to install package dependencies:
+- Use `npm` to install package dependencies (with peer dependencies):
 
     ```Bash
-    > npm install
+    > npm install --legacy-peer-deps
     ```
 
 - Start dev server locally:


### PR DESCRIPTION
Can't setup local development environment without installing peer dependencies of npm packages. That was removed in npm3, use legacy peer deps flag to get required peer react packages etc, and all new users to run latest luban