### PR TITLE
Fix: Missing parameter in parseAttribute call

### DIFF
--- a/src/shared/lib/SVGParser/AttributesParser.js
+++ b/src/shared/lib/SVGParser/AttributesParser.js
@@ -338,7 +338,7 @@ class AttributesParser {
                     if (kv.length === 2) {
                         const k = kv[0].trim();
                         const v = kv[1].trim();
-                        this.parseAttribute(attributes, parentAttributes, k, v);
+                        this.parseAttribute(attributes, parentAttributes, k, v, isTextElement);
                     }
                 }
                 break;


### PR DESCRIPTION
When parsing SVG files with 'style' attribute, the AttributesParser.parseAttribute recursively calls itself for every key:value block in 'style' attribute. 
The call invocation is missing last parameter, preventing 'style' attribute from being parsed correctly