### PR TITLE
Fix: Remove quotes from font-family

### DIFF
--- a/src/shared/lib/SVGParser/AttributesParser.js
+++ b/src/shared/lib/SVGParser/AttributesParser.js
@@ -272,7 +272,7 @@ class AttributesParser {
 
     parseAttribute(attributes, parentAttributes, key, value, isTextElement) {
         if (isTextElement && key === 'font-family') {
-            attributes.fontFamily = value;
+            attributes.fontFamily = value.replace(/['"]+/g, '');
         }
         switch (key) {
             case 'font-size': {


### PR DESCRIPTION
SVG files might have quotes in the font-family attribute. For example, when the font name contains spaces.

