### PR TITLE
Improvement: Keys for left/right nozzle for the dual extruder

### DIFF
--- a/src/app/resources/i18n/cs/resource.json
+++ b/src/app/resources/i18n/cs/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "",
     "key-settings/Add Material": "",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "",

--- a/src/app/resources/i18n/de/resource.json
+++ b/src/app/resources/i18n/de/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "Nozzle Diameter",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/en/resource.json
+++ b/src/app/resources/i18n/en/resource.json
@@ -2124,6 +2124,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "Nozzle Diameter",
+    "key-settings/Nozzle Diameter Left": "Left",
+    "key-settings/Nozzle Diameter Right": "Right",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "Extension",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/es/resource.json
+++ b/src/app/resources/i18n/es/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/fr/resource.json
+++ b/src/app/resources/i18n/fr/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/hu/resource.json
+++ b/src/app/resources/i18n/hu/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "",
     "key-settings/Add Material": "",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "",

--- a/src/app/resources/i18n/it/resource.json
+++ b/src/app/resources/i18n/it/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/ja/resource.json
+++ b/src/app/resources/i18n/ja/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/ko/resource.json
+++ b/src/app/resources/i18n/ko/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/pt-br/resource.json
+++ b/src/app/resources/i18n/pt-br/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "",
     "key-settings/Add Material": "",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "",

--- a/src/app/resources/i18n/ru/resource.json
+++ b/src/app/resources/i18n/ru/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Right Extruder",
     "key-settings/Add Material": "Add Material",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "Material Settings",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "Z-axis Linear Module",

--- a/src/app/resources/i18n/uk/resource.json
+++ b/src/app/resources/i18n/uk/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "Праве сопло",
     "key-settings/Add Material": "Додати матеріал",
     "key-settings/Nozzle Diameter": "Діаметр сопла",
+    "key-settings/Nozzle Diameter Left": "Ліве",
+    "key-settings/Nozzle Diameter Right": "Праве",
     "key-settings/Profile Manager": "Параметри матеріалу",
     "key-settings/Z-axis Extension": "Подовжений модуль вісі Z",
     "key-settings/Z-axis Module": "Модуль вісі Z",

--- a/src/app/resources/i18n/zh-cn/resource.json
+++ b/src/app/resources/i18n/zh-cn/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "右挤出机",
     "key-settings/Add Material": "新增材料",
     "key-settings/Nozzle Diameter": "喷嘴直径",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "材料设置",
     "key-settings/Z-axis Extension": "加长",
     "key-settings/Z-axis Module": "Z 轴直线模组",

--- a/src/app/resources/i18n/zh-tw/resource.json
+++ b/src/app/resources/i18n/zh-tw/resource.json
@@ -2110,6 +2110,8 @@
     "key-setting/Right-Nozzle": "",
     "key-settings/Add Material": "",
     "key-settings/Nozzle Diameter": "",
+    "key-settings/Nozzle Diameter Left": "",
+    "key-settings/Nozzle Diameter Right": "",
     "key-settings/Profile Manager": "",
     "key-settings/Z-axis Extension": "",
     "key-settings/Z-axis Module": "",

--- a/src/app/ui/pages/MachineMaterialSettings/MachineSettings.jsx
+++ b/src/app/ui/pages/MachineMaterialSettings/MachineSettings.jsx
@@ -445,11 +445,11 @@ const MachineSettings = forwardRef(({
                             isDualExtruder(selectedToolName) && (
                                 <div className="margin-top-16 width-248 height-32 background-grey-2 padding-2 border-radius-8">
                                     <Anchor className={`padding-left-8 border-radius-8 width-122 display-inline ${activeNozzle === LEFT ? 'background-color-white' : ''}`} onClick={() => setActiveNozzle(LEFT)}>
-                                        <span className="margin-right-8">{i18n._('key-Cnc/StlSection/orientation_Left-Left')}</span>
+                                        <span className="margin-right-8">{i18n._('key-settings/Nozzle Diameter Left')}</span>
                                         <span>{leftNozzleDiameter}</span>
                                     </Anchor>
                                     <Anchor className={`padding-left-8 border-radius-8 width-122 display-inline ${activeNozzle === RIGHT ? 'background-color-white' : ''}`} onClick={() => setActiveNozzle(RIGHT)}>
-                                        <span className="margin-right-8">{i18n._('key-Cnc/StlSection/orientation_Right-Right')}</span>
+                                        <span className="margin-right-8">{i18n._('key-settings/Nozzle Diameter Right')}</span>
                                         <span>{rightNozzleDiameter}</span>
                                     </Anchor>
                                 </div>


### PR DESCRIPTION
Added keys for left/right nozzle for the dual extruder nozzle diameter adjustment settings.

I've been trying to figure out for a while now why I can't get the labels for the left and right nozzles to translate properly in the dual extruder settings. The problem turned out to be that this part of the settings did not have its own parameters for translation. The keys used also for CNC are `key-Cnc/StlSection/orientation_Left-Left` and `key-Cnc/StlSection/orientation_Right-Right`. Here I present the changes that will eliminate this issue.