### PR TITLE
Improvement: Added white space at the end of sentence to the pop-up message when you saved g-code to a file.

### DIFF
--- a/src/app/ui/layouts/AppLayout.jsx
+++ b/src/app/ui/layouts/AppLayout.jsx
@@ -356,7 +356,7 @@ class AppLayout extends PureComponent {
                                     color="#4cb518"
                                 />
                                 <span>
-                                    {i18n._('key-app_layout-File Saved')}
+                                    {i18n._('key-app_layout-File Saved')}.&nbsp;
                                 </span>
                                 <Anchor
                                     onClick={openFolder}
@@ -367,7 +367,7 @@ class AppLayout extends PureComponent {
                                             textDecoration: 'underline'
                                         }}
                                     >
-                                        {i18n._('key-app_layout-Open Folder')}
+                                        {i18n._('key-app_layout-Open Folder')}.
                                     </span>
                                 </Anchor>
                             </div>


### PR DESCRIPTION
This is a minor improvement that add missing white space between keys `key-app_layout-File Saved` and `key-app_layout-Open Folder` to the pop-up message when you saved g-code to a file.

```diff
-Filed savedOpen folder
+Filed saved. Open folder.
```