### PR TITLE
Refactor: Unify use of preset models of left/right extruder

### DIFF
--- a/src/app/flux/printing/actions-scene.ts
+++ b/src/app/flux/printing/actions-scene.ts
@@ -34,16 +34,14 @@ const applyPrintSettingsToModels = () => (dispatch, getState) => {
 
     const {
         qualityDefinitions,
-        qualityDefinitionsRight,
         activePresetIds,
         modelGroup,
     } = getState().printing;
 
-    // TODO: Not only pick the left extruder
     const leftPresetModel = find(qualityDefinitions, {
         definitionId: activePresetIds[LEFT_EXTRUDER],
     });
-    const rightPresetModel = find(qualityDefinitionsRight, {
+    const rightPresetModel = find(qualityDefinitions, {
         definitionId: activePresetIds[RIGHT_EXTRUDER],
     });
 

--- a/src/app/flux/printing/index.js
+++ b/src/app/flux/printing/index.js
@@ -3538,19 +3538,20 @@ export const actions = {
         for (const model of modelGroup.getSelectedModelArray()) {
             const operation = new AddOperation3D({
                 target: model,
-                parent: null
+                parent: null,
             });
             operations.push(operation);
         }
         operations.registCallbackAfterAll(() => {
             dispatch(actions.updateState(modelGroup.getState()));
+            dispatch(actions.applyProfileToAllModels());
             dispatch(actions.destroyGcodeLine());
             dispatch(actions.displayModel());
         });
         dispatch(
             operationHistoryActions.setOperations(
                 INITIAL_STATE.name,
-                operations
+                operations,
             )
         );
 
@@ -3910,10 +3911,12 @@ export const actions = {
     undo: () => (dispatch, getState) => {
         const { history, displayedType } = getState().printing;
         const { canUndo } = history;
+
         if (displayedType !== 'model') {
             dispatch(actions.destroyGcodeLine());
             dispatch(actions.displayModel());
         }
+
         if (canUndo) {
             logToolBarOperation(HEAD_PRINTING, 'undo');
             dispatch(operationHistoryActions.undo(INITIAL_STATE.name));

--- a/src/app/flux/printing/index.js
+++ b/src/app/flux/printing/index.js
@@ -130,7 +130,7 @@ const definitionKeysWithDirection = {
     },
     right: {
         material: 'materialDefinitions',
-        quality: 'qualityDefinitionsRight',
+        quality: 'qualityDefinitions',
         extruder: 'extruderRDefinition'
     }
 };
@@ -175,7 +175,6 @@ const INITIAL_STATE = {
     defaultDefinitions: [],
     materialDefinitions: [],
     qualityDefinitions: [],
-    qualityDefinitionsRight: [],
 
     // isRecommended: true, // Using recommended settings, TODO: check to remove this
     defaultQualityId: 'quality.fast_print', // TODO: selectedQualityId
@@ -465,14 +464,10 @@ export const actions = {
         );
 
         const qualityParamModels = [];
-        const qualityParamModelsRight = [];
         const materialPresetModels = [];
 
         const activeMaterialType = dispatch(actions.getActiveMaterialType());
-        const activeMaterialTypeRight = dispatch(actions.getActiveMaterialType(undefined, RIGHT_EXTRUDER));
 
-        // const extruderLDefinition = await definitionManager.getDefinition('snapmaker_extruder_0');
-        // const extruderRDefinition = await definitionManager.getDefinition('snapmaker_extruder_1');
         const extruderLDefinition = definitionManager.extruderLDefinition;
         const extruderRDefinition = definitionManager.extruderRDefinition;
 
@@ -488,20 +483,12 @@ export const actions = {
                 extruderLDefinition?.settings?.machine_nozzle_size?.default_value,
             );
             qualityParamModels.push(paramModel);
-
-            const paramModelRight = new PresetDefinitionModel(
-                eachDefinition,
-                activeMaterialTypeRight,
-                extruderRDefinition?.settings?.machine_nozzle_size?.default_value,
-            );
-            qualityParamModelsRight.push(paramModelRight);
         });
 
         dispatch(
             actions.updateState({
                 materialDefinitions: materialPresetModels,
                 qualityDefinitions: qualityParamModels,
-                qualityDefinitionsRight: qualityParamModelsRight,
                 extruderLDefinition,
                 extruderRDefinition,
             })
@@ -600,7 +587,6 @@ export const actions = {
         });
 
         const qualityPresetModels = [];
-        const qualityPresetModelsRight = [];
         for (const preset of allQualityDefinitions) {
             const paramModel = new PresetDefinitionModel(
                 preset,
@@ -608,13 +594,6 @@ export const actions = {
                 definitionManager.extruderLDefinition?.settings?.machine_nozzle_size?.default_value,
             );
             qualityPresetModels.push(paramModel);
-
-            const paramModelRight = new PresetDefinitionModel(
-                preset,
-                activeMaterialType,
-                definitionManager.extruderRDefinition?.settings?.machine_nozzle_size?.default_value,
-            );
-            qualityPresetModelsRight.push(paramModelRight);
         }
 
         const defaultDefinitions = definitionManager?.defaultDefinitions.map((eachDefinition) => {
@@ -630,7 +609,6 @@ export const actions = {
                 defaultDefinitions: defaultDefinitions,
                 materialDefinitions: materialParamModels,
                 qualityDefinitions: qualityPresetModels,
-                qualityDefinitionsRight: qualityPresetModelsRight,
                 printingProfileLevel: definitionManager.printingProfileLevel,
                 materialProfileLevel: definitionManager.materialProfileLevel,
             })
@@ -1626,7 +1604,7 @@ export const actions = {
         type,
         definition,
         newDefinitionId,
-        newDefinitionName
+        newDefinitionName,
     ) => async (dispatch, getState) => {
         const state = getState().printing;
         let name = newDefinitionName || definition.name;
@@ -1695,11 +1673,20 @@ export const actions = {
             extruderLDefinition?.settings?.machine_nozzle_size?.default_value,
         );
 
-        dispatch(
-            actions.updateState({
-                [definitionsKey]: [...state[definitionsKey], createdDefinitionModel]
-            })
-        );
+        // TODO: Refactor this
+        if (type === PRINTING_MANAGER_TYPE_QUALITY) {
+            dispatch(
+                actions.updateState({
+                    [definitionsKey]: [...state[definitionsKey], createdDefinitionModel]
+                })
+            );
+        } else {
+            dispatch(
+                actions.updateState({
+                    [definitionsKey]: [...state[definitionsKey], createdDefinitionModel]
+                })
+            );
+        }
 
         return createdDefinitionModel;
     },

--- a/src/app/flux/printing/index.js
+++ b/src/app/flux/printing/index.js
@@ -1991,23 +1991,21 @@ export const actions = {
      * @param stackId
      */
     validateActiveQualityPreset: (stackId = LEFT_EXTRUDER) => (dispatch, getState) => {
-        const { qualityDefinitions, qualityDefinitionsRight, activePresetIds } = getState().printing;
-
-        const presetModels = stackId === LEFT_EXTRUDER ? qualityDefinitions : qualityDefinitionsRight;
+        const { qualityDefinitions, activePresetIds } = getState().printing;
 
         const materialType = dispatch(actions.getActiveMaterialType(undefined, stackId));
 
-        const presetModel = presetModels.find(p => p.definitionId === activePresetIds[stackId]);
+        const presetModel = qualityDefinitions.find(p => p.definitionId === activePresetIds[stackId]);
 
         // TODO: Consider nozzle size
         // machineNozzleSize: actualExtruderDefinition.settings?.machine_nozzle_size?.default_value,
-        if (presetModel && isQualityPresetVisible(presetModel, { materialType: materialType })) {
+        if (presetModel && isQualityPresetVisible(qualityDefinitions, { materialType: materialType })) {
             // the quality preset looks fine
             return;
         }
 
         // find a new quality preset for active material type
-        for (const presetModel2 of presetModels) {
+        for (const presetModel2 of qualityDefinitions) {
             const visible = isQualityPresetVisible(presetModel2, { materialType: materialType });
             if (visible) {
                 dispatch(actions.updateActiveQualityPresetId(stackId, presetModel2.definitionId));
@@ -2172,7 +2170,6 @@ export const actions = {
             defaultMaterialId,
             defaultMaterialIdRight,
             qualityDefinitions,
-            qualityDefinitionsRight,
             materialDefinitions,
         } = getState().printing;
         modelGroup.updateClippingPlane();
@@ -2192,7 +2189,7 @@ export const actions = {
         // update extruder definitions
         const qualityPresets = {
             [LEFT_EXTRUDER]: qualityDefinitions.find(p => p.definitionId === activePresetIds[LEFT_EXTRUDER]),
-            [RIGHT_EXTRUDER]: qualityDefinitionsRight.find(p => p.definitionId === activePresetIds[RIGHT_EXTRUDER]),
+            [RIGHT_EXTRUDER]: qualityDefinitions.find(p => p.definitionId === activePresetIds[RIGHT_EXTRUDER]),
         };
 
         const globalQualityPreset = cloneDeep(qualityPresets[LEFT_EXTRUDER]);

--- a/src/app/models/ModelGroup.ts
+++ b/src/app/models/ModelGroup.ts
@@ -1181,6 +1181,7 @@ class ModelGroup extends EventEmitter {
         // TODO: paste all objects from clipboard without losing their relative positions
         modelsToCopy.forEach((model) => {
             if (model instanceof PrimeTowerModel) return;
+
             const newModel = model.clone(this);
             if (newModel.parent) {
                 ThreeUtils.removeObjectParent(newModel.meshObject);

--- a/src/app/models/ThreeGroup.ts
+++ b/src/app/models/ThreeGroup.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { cloneDeep } from 'lodash';
 import { BufferGeometryUtils } from 'three/examples/jsm/utils/BufferGeometryUtils';
 import BaseModel, { ModelTransformation, ModelInfo, TSize } from './ThreeBaseModel';
 import type ModelGroup from './ModelGroup';
@@ -344,7 +345,7 @@ export default class ThreeGroup extends BaseModel {
             mode: this.mode,
             transformation: this.transformation,
             processImageName: this.processImageName,
-            extruderConfig: this.extruderConfig
+            extruderConfig: cloneDeep(this.extruderConfig),
         };
         this.children.forEach((model) => {
             clonedSubModels.push(model.clone(modelGroup));

--- a/src/app/ui/layouts/AppLayout.jsx
+++ b/src/app/ui/layouts/AppLayout.jsx
@@ -1,24 +1,13 @@
-import React, { PureComponent } from 'react';
-import { Group } from 'three';
-import { withRouter } from 'react-router-dom';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import isElectron from 'is-electron';
-import Mousetrap from 'mousetrap';
-import i18next from 'i18next';
 import classNames from 'classnames';
+import i18next from 'i18next';
+import isElectron from 'is-electron';
 import { cloneDeep, throttle } from 'lodash';
-import Checkbox from '../components/Checkbox';
-import { Button } from '../components/Buttons';
-import { renderModal } from '../utils';
-import AppBar from '../views/AppBar';
-import i18n from '../../lib/i18n';
-import UniApi from '../../lib/uni-api';
-import { checkIsGCodeFile, checkIsSnapmakerProjectFile } from '../../lib/check-name';
-import Settings from '../pages/Settings/Settings';
-import FirmwareTool from '../pages/Settings/FirmwareTool';
-import SoftwareUpdate from '../pages/Settings/SoftwareUpdate';
-import DownloadUpdate from '../pages/Settings/SoftwareUpdate/DownloadUpdate';
+import Mousetrap from 'mousetrap';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { Group } from 'three';
 
 import {
     COORDINATE_MODE_BOTTOM_CENTER,
@@ -37,21 +26,38 @@ import {
     SUPPORT_ZH_URL,
     TUTORIAL_VIDEO_URL
 } from '../../constants';
-import { actions as menuActions } from '../../flux/appbar-menu';
-import { actions as machineActions } from '../../flux/machine';
-import { actions as editorActions } from '../../flux/editor';
-import { actions as projectActions } from '../../flux/project';
-import { actions as operationHistoryActions } from '../../flux/operation-history';
-import { actions as settingsActions } from '../../flux/setting';
+
 import { actions as appGlobalActions } from '../../flux/app-global';
-import styles from './styles/appbar.styl';
+import { actions as menuActions } from '../../flux/appbar-menu';
+import { actions as editorActions } from '../../flux/editor';
+import { actions as machineActions } from '../../flux/machine';
+import { actions as operationHistoryActions } from '../../flux/operation-history';
+import { actions as projectActions } from '../../flux/project';
+import { actions as settingsActions } from '../../flux/setting';
+
+import { checkIsGCodeFile, checkIsSnapmakerProjectFile } from '../../lib/check-name';
+import { logLubanQuit } from '../../lib/gaEvent';
+import i18n from '../../lib/i18n';
+import UniApi from '../../lib/uni-api';
+import { getCurrentHeadType } from '../../lib/url-utils';
+
+import Anchor from '../components/Anchor';
+import { Button } from '../components/Buttons';
+import Checkbox from '../components/Checkbox';
+import Space from '../components/Space';
+import SvgIcon from '../components/SvgIcon';
+
+import FirmwareTool from '../pages/Settings/FirmwareTool';
+import Settings from '../pages/Settings/Settings';
+import SoftwareUpdate from '../pages/Settings/SoftwareUpdate';
+import DownloadUpdate from '../pages/Settings/SoftwareUpdate/DownloadUpdate';
+
+import { renderModal } from '../utils';
+import AppBar from '../views/AppBar';
 // import HomePage from '../pages/HomePage';
 // import Workspace from '../pages/Workspace';
 import ModelExporter from '../widgets/PrintingVisualizer/ModelExporter';
-import Anchor from '../components/Anchor';
-import SvgIcon from '../components/SvgIcon';
-import { logLubanQuit } from '../../lib/gaEvent';
-import { getCurrentHeadType } from '../../lib/url-utils';
+import styles from './styles/appbar.styl';
 
 class AppLayout extends PureComponent {
     static propTypes = {
@@ -210,7 +216,9 @@ class AppLayout extends PureComponent {
                     return (<SoftwareUpdate />);
                 },
                 shouldRenderFooter: false,
-                renderFooter() { return null; },
+                renderFooter() {
+                    return null;
+                },
                 onClose,
                 actions: []
             });
@@ -241,7 +249,9 @@ class AppLayout extends PureComponent {
                             <div className="display-inline height-32">
                                 <Checkbox
                                     checked={shouldCheckForUpdate}
-                                    onChange={(event) => { this.props.updateShouldCheckForUpdate(event.target.checked); }}
+                                    onChange={(event) => {
+                                        this.props.updateShouldCheckForUpdate(event.target.checked);
+                                    }}
 
                                 />
                                 <span className="margin-left-4">
@@ -355,9 +365,8 @@ class AppLayout extends PureComponent {
                                     type={['static']}
                                     color="#4cb518"
                                 />
-                                <span>
-                                    {i18n._('key-app_layout-File Saved')}.&nbsp;
-                                </span>
+                                <span>{i18n._('key-app_layout-File Saved')}</span>
+                                <Space width={4} />
                                 <Anchor
                                     onClick={openFolder}
                                 >
@@ -367,7 +376,7 @@ class AppLayout extends PureComponent {
                                             textDecoration: 'underline'
                                         }}
                                     >
-                                        {i18n._('key-app_layout-Open Folder')}.
+                                        {i18n._('key-app_layout-Open Folder')}
                                     </span>
                                 </Anchor>
                             </div>
@@ -570,8 +579,11 @@ class AppLayout extends PureComponent {
                 switch (pathname) {
                     case '/printing':
                     case '/laser':
-                    case '/cnc': this.actions.saveAsFile(file); break;
-                    default: break;
+                    case '/cnc':
+                        this.actions.saveAsFile(file);
+                        break;
+                    default:
+                        break;
                 }
             });
             UniApi.Event.on('appbar-menu:save', () => {
@@ -579,8 +591,11 @@ class AppLayout extends PureComponent {
                 switch (pathname) {
                     case '/printing':
                     case '/laser':
-                    case '/cnc': this.actions.save(); break;
-                    default: break;
+                    case '/cnc':
+                        this.actions.save();
+                        break;
+                    default:
+                        break;
                 }
             });
             UniApi.Event.on('save-and-close', async () => {
@@ -670,11 +685,20 @@ class AppLayout extends PureComponent {
             });
             UniApi.Event.on('appbar-menu:window', (type) => {
                 switch (type) {
-                    case 'reload': UniApi.Window.reload(); break;
-                    case 'forceReload': UniApi.Window.forceReload(); break;
-                    case 'viewInBrowser': UniApi.Window.viewInBrowser(); break;
-                    case 'toggleFullscreen': UniApi.Window.toggleFullscreen(); break;
-                    default: break;
+                    case 'reload':
+                        UniApi.Window.reload();
+                        break;
+                    case 'forceReload':
+                        UniApi.Window.forceReload();
+                        break;
+                    case 'viewInBrowser':
+                        UniApi.Window.viewInBrowser();
+                        break;
+                    case 'toggleFullscreen':
+                        UniApi.Window.toggleFullscreen();
+                        break;
+                    default:
+                        break;
                 }
             });
             UniApi.Event.on('appbar-menu:help.link', (type) => {
@@ -712,7 +736,8 @@ class AppLayout extends PureComponent {
                     case 'myminifactory':
                         UniApi.Window.openLink(MYMINIFACTORY_URL);
                         break;
-                    default: break;
+                    default:
+                        break;
                 }
             });
             UniApi.Event.on('appbar-menu:shortcut', (...commands) => {
@@ -777,11 +802,20 @@ class AppLayout extends PureComponent {
                     }
                 }
                 switch (pathname) {
-                    case '/printing': UniApi.Event.emit('appbar-menu:printing.import', fileObj); break;
-                    case '/laser': UniApi.Event.emit('appbar-menu:laser.import', fileObj); break;
-                    case '/cnc': UniApi.Event.emit('appbar-menu:cnc.import', fileObj); break;
-                    case '/workspace': UniApi.Event.emit('appbar-menu:workspace.import', fileObj); break;
-                    default: break;
+                    case '/printing':
+                        UniApi.Event.emit('appbar-menu:printing.import', fileObj);
+                        break;
+                    case '/laser':
+                        UniApi.Event.emit('appbar-menu:laser.import', fileObj);
+                        break;
+                    case '/cnc':
+                        UniApi.Event.emit('appbar-menu:cnc.import', fileObj);
+                        break;
+                    case '/workspace':
+                        UniApi.Event.emit('appbar-menu:workspace.import', fileObj);
+                        break;
+                    default:
+                        break;
                 }
             });
             UniApi.Event.on('appbar-menu:export-model', () => {
@@ -813,11 +847,20 @@ class AppLayout extends PureComponent {
             UniApi.Event.on('appbar-menu:export-gcode', () => {
                 const pathname = this.props.currentModalPath || this.props.history.location.pathname;
                 switch (pathname) {
-                    case '/printing': UniApi.Event.emit('appbar-menu:printing.export-gcode'); break;
-                    case '/laser': UniApi.Event.emit('appbar-menu:cnc-laser.export-gcode'); break;
-                    case '/cnc': UniApi.Event.emit('appbar-menu:cnc-laser.export-gcode'); break;
-                    case '/workspace': UniApi.Event.emit('appbar-menu:workspace.export-gcode'); break;
-                    default: break;
+                    case '/printing':
+                        UniApi.Event.emit('appbar-menu:printing.export-gcode');
+                        break;
+                    case '/laser':
+                        UniApi.Event.emit('appbar-menu:cnc-laser.export-gcode');
+                        break;
+                    case '/cnc':
+                        UniApi.Event.emit('appbar-menu:cnc-laser.export-gcode');
+                        break;
+                    case '/workspace':
+                        UniApi.Event.emit('appbar-menu:workspace.export-gcode');
+                        break;
+                    default:
+                        break;
                 }
             });
 

--- a/src/app/ui/views/PresetModifier/ParametersTableView.tsx
+++ b/src/app/ui/views/PresetModifier/ParametersTableView.tsx
@@ -44,8 +44,11 @@ interface DisplayConfig {
  * @param settings
  * @param parameterConverter
  */
-function calculateDisplayConfigsForKeys(keys: string[], settings: { [key: string]: any },
-    parameterConverter: (key) => DisplayConfig | null): DisplayConfig[] {
+function calculateDisplayConfigsForKeys(
+    keys: string[],
+    settings: { [key: string]: any },
+    parameterConverter: (key) => DisplayConfig | null,
+): DisplayConfig[] {
     const displayConfigs = [];
     for (const key of keys) {
         let displayConfig: DisplayConfig = null;
@@ -216,7 +219,7 @@ const ParametersTableView: React.FC<TProps> = (props) => {
     } = props;
 
     // Category anchors
-    const [activeCateId, setActiveCateId] = useState(2);
+    const [activeCateId, setActiveCateId] = useState(0);
 
     const scrollDom = useRef(null);
     const fieldsDom = useRef([]);
@@ -297,28 +300,28 @@ const ParametersTableView: React.FC<TProps> = (props) => {
                 )}
             >
                 {
-                    Object.keys(optionConfigGroup).map((category, index) => {
-                        const keys = optionConfigGroup[category];
+                    Object.keys(displayConfigsGroups).map((category, index) => {
+                        const displayConfigs = displayConfigsGroups[category];
 
-                        if (keys.length) {
-                            return (
-                                <div key={category} className="margin-vertical-4">
-                                    <Anchor
-                                        className={classNames(styles.item, {
-                                            [styles.selected]:
-                                            index === activeCateId
-                                        })}
-                                        onClick={() => {
-                                            setActiveCate(index);
-                                        }}
-                                    >
-                                        <span className="sm-parameter-header__title">{i18n._(`key-Definition/Category-${category}`)}</span>
-                                    </Anchor>
-                                </div>
-                            );
-                        } else {
+                        if (!displayConfigs.length) {
                             return null;
                         }
+
+                        return (
+                            <div key={category} className="margin-vertical-4">
+                                <Anchor
+                                    className={classNames(styles.item, {
+                                        [styles.selected]:
+                                        index === activeCateId
+                                    })}
+                                    onClick={() => {
+                                        setActiveCate(index);
+                                    }}
+                                >
+                                    <span className="sm-parameter-header__title">{i18n._(`key-Definition/Category-${category}`)}</span>
+                                </Anchor>
+                            </div>
+                        );
                     })
                 }
             </div>
@@ -350,7 +353,10 @@ const ParametersTableView: React.FC<TProps> = (props) => {
                                 const displayConfigs = displayConfigsGroups[category];
 
                                 if (!displayConfigs.length) {
-                                    return null;
+                                    // leave a empty <div> so anchors won't break
+                                    return (
+                                        <div key={category} />
+                                    );
                                 }
 
                                 return (

--- a/src/app/ui/views/PresetModifier/PresetContent.jsx
+++ b/src/app/ui/views/PresetModifier/PresetContent.jsx
@@ -110,8 +110,7 @@ const PresetContent = (
     const helpersExtruderConfig = useSelector((state) => state.printing.helpersExtruderConfig);
 
     const {
-        qualityDefinitions,
-        qualityDefinitionsRight,
+        qualityDefinitions: qualityPresetModels,
         // printingParamsType,
         customMode,
     } = useSelector(state => state?.printing);
@@ -124,8 +123,7 @@ const PresetContent = (
 
     // Update preset model and option config group
     useEffect(() => {
-        const presetModels = selectedStackId === LEFT_EXTRUDER ? qualityDefinitions : qualityDefinitionsRight;
-        const newPresetModel = presetModels.find(p => p.definitionId === selectedPresetId);
+        const newPresetModel = qualityPresetModels.find(p => p.definitionId === selectedPresetId);
         setPresetModel(newPresetModel);
 
         if (selectedStackId === LEFT_EXTRUDER) {

--- a/src/app/ui/views/PresetModifier/PresetModifierModal.jsx
+++ b/src/app/ui/views/PresetModifier/PresetModifierModal.jsx
@@ -29,8 +29,7 @@ function PresetModifierModal(
 
     const {
         defaultDefinitions,
-        qualityDefinitions,
-        qualityDefinitionsRight,
+        qualityDefinitions: qualityPresetModels,
         activePresetIds,
     } = useSelector(state => state?.printing);
 
@@ -61,8 +60,7 @@ function PresetModifierModal(
      * @param presetId
      */
     function selectPreset(presetId) {
-        const presetModels = selectedStackId === LEFT_EXTRUDER ? qualityDefinitions : qualityDefinitionsRight;
-        const presetModel = presetModels.find(p => p.definitionId === presetId);
+        const presetModel = qualityPresetModels.find(p => p.definitionId === presetId);
         if (presetModel) {
             setSelectedPresetId(presetId);
             dispatch(printingActions.updateActiveQualityPresetId(selectedStackId, presetId));

--- a/src/app/ui/views/PresetModifier/StackPresetSelector.tsx
+++ b/src/app/ui/views/PresetModifier/StackPresetSelector.tsx
@@ -151,8 +151,7 @@ const StackPresetSelector: React.FC<StackPresetSelectorProps> = ({ selectedStack
 
     // quality
     const {
-        qualityDefinitions,
-        qualityDefinitionsRight,
+        qualityDefinitions: qualityPresetModels,
         materialDefinitions,
         defaultMaterialId,
         defaultMaterialIdRight,
@@ -166,12 +165,10 @@ const StackPresetSelector: React.FC<StackPresetSelectorProps> = ({ selectedStack
     const [expandedPresetCategories, setExpandedPresetCategories] = useState([PRESET_CATEGORY_DEFAULT]);
 
     useEffect(() => {
-        const presetModels = selectedStackId === LEFT_EXTRUDER ? qualityDefinitions : qualityDefinitionsRight;
-
         const materialPresetId = selectedStackId === LEFT_EXTRUDER ? defaultMaterialId : defaultMaterialIdRight;
         const materialPreset = materialDefinitions.find(p => p.definitionId === materialPresetId);
 
-        const newPresetOptionsObj = getPresetOptions(presetModels, materialPreset);
+        const newPresetOptionsObj = getPresetOptions(qualityPresetModels, materialPreset);
         setPresetOptionsObj(newPresetOptionsObj);
 
         const newCategories = Object.keys(newPresetOptionsObj);
@@ -179,12 +176,11 @@ const StackPresetSelector: React.FC<StackPresetSelectorProps> = ({ selectedStack
 
         // set all preset categories expanded
         setExpandedPresetCategories(Object.keys(newPresetOptionsObj));
-    }, [selectedStackId, defaultMaterialId, defaultMaterialIdRight, qualityDefinitions, qualityDefinitionsRight]);
+    }, [selectedStackId, defaultMaterialId, defaultMaterialIdRight, qualityPresetModels]);
 
     // Get active preset model
     useEffect(() => {
-        const presetModels = selectedStackId === LEFT_EXTRUDER ? qualityDefinitions : qualityDefinitionsRight;
-        const targetPresetModel = presetModels.find(p => p.definitionId === selectedPresetId);
+        const targetPresetModel = qualityPresetModels.find(p => p.definitionId === selectedPresetId);
         setPresetModel(targetPresetModel);
     }, [selectedStackId, selectedPresetId]);
 

--- a/src/app/ui/widgets/CncLaserList/ObjectList/ObjectListBox.jsx
+++ b/src/app/ui/widgets/CncLaserList/ObjectList/ObjectListBox.jsx
@@ -1,13 +1,13 @@
 // import React, { PureComponent } from 'react';
 import classNames from 'classnames';
-import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
-import { useSelector, useDispatch, shallowEqual } from 'react-redux';
-import styles from '../styles.styl';
+import React, { useEffect } from 'react';
+import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { actions as editorActions } from '../../../../flux/editor';
-import modal from '../../../../lib/modal';
 import i18n from '../../../../lib/i18n';
+import modal from '../../../../lib/modal';
 import ModelItem from '../../../views/model-item';
+import styles from '../styles.styl';
 
 
 function ObjectListBox({ headType }) {
@@ -53,28 +53,38 @@ function ObjectListBox({ headType }) {
     return (
         <div
             className={classNames(
-                'width-264',
-                'background-color-white',
                 styles['object-list-box'],
+                'width-264',
             )}
         >
-            {
-                allModels && allModels.map((model) => {
-                    return (
-                        <ModelItem
-                            model={model}
-                            key={model.modelID}
-                            visible={model.visible}
-                            styles={styles}
-                            isSelected={selectedModelArray && selectedModelArray.includes(model)}
-                            onSelect={actions.onClickModelNameBox}
-                            onToggleVisible={actions.onClickModelHideBox}
-                            inProgress={inProgress}
-                            placement="right"
-                        />
-                    );
-                })
-            }
+            <div className={classNames('padding-vertical-4')}>
+                {
+                    allModels && allModels.map((model) => {
+                        return (
+                            <ModelItem
+                                model={model}
+                                key={model.modelID}
+                                visible={model.visible}
+                                styles={styles}
+                                isSelected={selectedModelArray && selectedModelArray.includes(model)}
+                                onSelect={actions.onClickModelNameBox}
+                                onToggleVisible={actions.onClickModelHideBox}
+                                inProgress={inProgress}
+                                placement="right"
+                            />
+                        );
+                    })
+                }
+                {
+                    allModels && allModels.length === 0 && (
+                        <div className="padding-vertical-4 padding-horizontal-8">
+                            <div className="height-24">
+                                <span>{i18n._('key-Printing/No model(s).')}</span>
+                            </div>
+                        </div>
+                    )
+                }
+            </div>
         </div>
     );
 }

--- a/src/app/ui/widgets/CncLaserList/ObjectList/index.jsx
+++ b/src/app/ui/widgets/CncLaserList/ObjectList/index.jsx
@@ -1,3 +1,3 @@
 import CncLaserObjectList from './ObjectListBox';
 
-export default (CncLaserObjectList);
+export default CncLaserObjectList;

--- a/src/app/ui/widgets/CncLaserShared/VisualizerBottomLeft.jsx
+++ b/src/app/ui/widgets/CncLaserShared/VisualizerBottomLeft.jsx
@@ -21,14 +21,18 @@ const VisualizerBottomLeft = ({ headType, toFront, zoomOut, zoomIn, scale, minSc
                 cursor: 'auto',
             }}
         >
-            <Card
-                className={classNames('margin-horizontal-8')}
-                title={i18n._('key-CncLaser/ObjectList_Title-Object List')}
-            >
-                <CncLaserObjectList
-                    headType={headType}
-                />
-            </Card>
+            <div className="margin-horizontal-8">
+                <div className="margin-bottom-8">
+                    <Card
+                        title={i18n._('key-CncLaser/ObjectList_Title-Object List')}
+                        hasToggleButton
+                    >
+                        <CncLaserObjectList
+                            headType={headType}
+                        />
+                    </Card>
+                </div>
+            </div>
             <div className={classNames('margin-horizontal-8', 'height-24')}>
                 <SvgIcon
                     name="ViewFix"

--- a/src/app/ui/widgets/PrintingConfigurationWidget/ConfigurationView.tsx
+++ b/src/app/ui/widgets/PrintingConfigurationWidget/ConfigurationView.tsx
@@ -62,7 +62,6 @@ const ConfigurationView: React.FC<{}> = () => {
     const {
         // quality
         qualityDefinitions: qualityDefinitionModels,
-        qualityDefinitionsRight: qualityDefinitionModelsRight,
         activePresetIds,
 
         // material
@@ -97,7 +96,7 @@ const ConfigurationView: React.FC<{}> = () => {
     if (selectedStackId === LEFT_EXTRUDER) {
         presetOptionsObj = getPresetOptions(qualityDefinitionModels, materialPreset);
     } else {
-        presetOptionsObj = getPresetOptions(qualityDefinitionModelsRight, materialPresetRight);
+        presetOptionsObj = getPresetOptions(qualityDefinitionModels, materialPresetRight);
     }
 
     const presetCategoryOptions = Object.values(presetOptionsObj).map((item) => {
@@ -156,9 +155,7 @@ const ConfigurationView: React.FC<{}> = () => {
     // Update preset model
     useEffect(() => {
         const presetId = activePresetIds[selectedStackId];
-
-        const allModels = selectedStackId === LEFT_EXTRUDER ? qualityDefinitionModels : qualityDefinitionModelsRight;
-        const presetModel = allModels.find(p => p.definitionId === presetId);
+        const presetModel = qualityDefinitionModels.find(p => p.definitionId === presetId);
 
         // Update currently selected preset model
         if (presetModel) {
@@ -172,7 +169,7 @@ const ConfigurationView: React.FC<{}> = () => {
             // refresh the scene on preset model changed
             displayModel();
         }
-    }, [selectedStackId, activePresetIds, qualityDefinitionModels, qualityDefinitionModelsRight]);
+    }, [selectedStackId, activePresetIds, qualityDefinitionModels]);
 
 
     const i18nContent = {
@@ -289,7 +286,7 @@ const ConfigurationView: React.FC<{}> = () => {
                             // TODO: need update
                             const createdDefinitionModel = await dispatch(
                                 printingActions.duplicateDefinitionByType(
-                                    'quality',
+                                    PRINTING_MANAGER_TYPE_QUALITY,
                                     newSelectedDefinition,
                                     undefined,
                                     newName

--- a/src/app/ui/widgets/PrintingConfigurationWidget/PresetInitialization.tsx
+++ b/src/app/ui/widgets/PrintingConfigurationWidget/PresetInitialization.tsx
@@ -17,7 +17,6 @@ const PresetInitialization: React.FC = () => {
 
     const {
         qualityDefinitions: qualityDefinitionModels,
-        qualityDefinitionsRight: qualityDefinitionModelsRight,
         activePresetIds,
 
         materialDefinitions,
@@ -50,11 +49,11 @@ const PresetInitialization: React.FC = () => {
     }, [qualityDefinitionModels, activePresetIds, defaultMaterialId]);
 
     useEffect(() => {
-        if (qualityDefinitionModelsRight.length > 0) {
-            let presetModel = qualityDefinitionModelsRight.find(p => p.definitionId === activePresetIds[RIGHT_EXTRUDER]);
+        if (qualityDefinitionModels.length > 0) {
+            let presetModel = qualityDefinitionModels.find(p => p.definitionId === activePresetIds[RIGHT_EXTRUDER]);
             if (!presetModel) {
                 // definition no found, select first official definition
-                const availablePresetModels = pickAvailablePresetModels(qualityDefinitionModelsRight, materialPresetRight);
+                const availablePresetModels = pickAvailablePresetModels(qualityDefinitionModels, materialPresetRight);
                 presetModel = availablePresetModels.length > 0 && availablePresetModels[0];
 
                 if (presetModel) {
@@ -64,7 +63,7 @@ const PresetInitialization: React.FC = () => {
                 }
             }
         }
-    }, [qualityDefinitionModelsRight, activePresetIds, defaultMaterialIdRight]);
+    }, [qualityDefinitionModels, activePresetIds, defaultMaterialIdRight]);
 
     return (<div className="display-none" />);
 };


### PR DESCRIPTION
Note:

- Also fixed prepend G-code in A150/A250/A350 with single extruder, the G-code attached in #1878 can used as example (but it's a different issue)
- Fix broken anchors on parameter table