### PR TITLE
Fix: Fix redirect for non-english links

### DIFF
--- a/src/app/ui/pages/HomePage/MoreInfo.jsx
+++ b/src/app/ui/pages/HomePage/MoreInfo.jsx
@@ -17,7 +17,7 @@ const MoreInfo = () => {
                         {i18n._('key-HomePage/Begin-Software Manual')}
                     </span>
                 </a>
-                <a className={classNames(styles.listItem, styles['right-part'])} href={lang === 'en' ? 'https://support.snapmaker.com/hc/en-us' : 'https://support.snapmaker.com/hc/zh-cn'} target="_blank" rel="noopener noreferrer">
+                <a className={classNames(styles.listItem, styles['right-part'])} href={lang !== 'zh-cn' ? 'https://support.snapmaker.com/hc/en-us' : 'https://support.snapmaker.com/hc/zh-cn'} target="_blank" rel="noopener noreferrer">
                     <span className={classNames('heading-3-normal-with-hover')}>
                         {i18n._('key-HomePage/Begin-Support')}
                     </span>
@@ -32,12 +32,12 @@ const MoreInfo = () => {
                         {i18n._('key-HomePage/Begin-Forum')}
                     </span>
                 </a>
-                <a className={classNames(styles.listItem)} href={lang === 'en' ? 'https://snapmaker.com' : 'https://snapmaker.cn/'} target="_blank" rel="noopener noreferrer">
+                <a className={classNames(styles.listItem)} href={lang !== 'zh-cn' ? 'https://snapmaker.com' : 'https://snapmaker.cn/'} target="_blank" rel="noopener noreferrer">
                     <span className={classNames('heading-3-normal-with-hover')}>
                         {i18n._('key-HomePage/Begin-Snapmaker.com')}
                     </span>
                 </a>
-                <a className={classNames(styles.listItem, styles['right-part'])} href={lang === 'en' ? 'https://shop.snapmaker.com/' : 'https://snapmaker.world.tmall.com/?spm=a1z10.3-b.w5001-21696184167.3.40be7f386PAuCQ&scene=taobao_shop'} target="_blank" rel="noopener noreferrer">
+                <a className={classNames(styles.listItem, styles['right-part'])} href={lang !== 'zh-cn' ? 'https://shop.snapmaker.com/' : 'https://snapmaker.world.tmall.com/?spm=a1z10.3-b.w5001-21696184167.3.40be7f386PAuCQ&scene=taobao_shop'} target="_blank" rel="noopener noreferrer">
                     <span className={classNames('heading-3-normal-with-hover')}>
                         {i18n._('key-HomePage/Begin-Store')}
                     </span>


### PR DESCRIPTION
If the language is different from English, the link from the main window leads to the Chinese version of the site, store and support service.