### PR TITLE
Correct syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's recommended to use a stable release version unless you want to do some modi
 For Linux distros (Debian for example), you may need to run following commands to install dependencies for Luban:
 
 ```Bashhist
-> sudo dpkg install snapmaker-luban-{version}-linux-amd64.deb
+> sudo dpkg --install snapmaker-luban-{version}-linux-amd64.deb
 > sudo apt install --fix-broken
 ```
 


### PR DESCRIPTION
Issue: The syntax to install a .deb package using dpkg is `dpkg --install [filename.deb]`. 

Solution: This commit adds the missing `--` to the codeblock within README.md which holds the example commands for installing via dpkg.

This commit does not affect any code, therefore no testing has been performed.

Found 0 issues of any status mentioning this, and 0 open PRs affecting README.md.