### PR TITLE
Build: Fix build script by use npm@^9 instead of latest

### DIFF
--- a/.github/workflows/build-on-create-release.yml
+++ b/.github/workflows/build-on-create-release.yml
@@ -30,7 +30,7 @@ jobs:
               with:
                   node-version: 16
 
-            - run: npm install -g npm@latest
+            - run: npm install -g npm@^9
             - run: npm install
 
             - run: npm run build
@@ -69,7 +69,7 @@ jobs:
               with:
                   node-version: 16
 
-            - run: npm install -g npm@latest
+            - run: npm install -g npm@^9
             - run: npm install
 
             - run: npm run build
@@ -129,7 +129,7 @@ jobs:
               with:
                   node-version: 16
 
-            - run: npm install -g npm@latest
+            - run: npm install -g npm@^9
             - run: npm install
 
             - run: npm run build


### PR DESCRIPTION
1. npm v10 requires we upgrade Node.js to v18
2. Node.js v18 requires we upgrade all whole webpack to v5 immediately
3. Temporary solution: use npm v9 until we upgrade webpack to v5 (Node timeline: https://nodejs.dev/en/about/releases/)
