### PR TITLE
Improvement: removing gconf2 gconf-service libappindicator1

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -81,10 +81,7 @@ linux:
 
 deb:
     depends:
-        - gconf2
-        - gconf-service
         - libnotify4
-        - libappindicator1
         - libxtst6
         - libnss3
         - libasound2


### PR DESCRIPTION
Suggest removing gconf2 gconf-service libappindicator1 as no longer needed  for gnome in Ubuntu  or Debian.    Without  removal, dpkg and/or apt will fail.

Upstream project documenation:  https://www.electron.build/configuration/linux#deb

#### With current  release snapmaker-luban-4.9.1-linux-amd64.deb ####
`The following packages have unmet dependencies:
 snapmaker-luban : Depends: gconf2 but it is not installable
                   Depends: gconf-service but it is not installable
                   Depends: libappindicator1 but it is not installable`



