### PR TITLE
Fix: v4.10.2 part5

### DIFF
--- a/src/app/constants/index.ts
+++ b/src/app/constants/index.ts
@@ -768,9 +768,9 @@ export const LASER_DEFAULT_GCODE_PARAMETERS_DEFINITION = {
     fillInterval: {
         label: 'Fill Interval',
         description:
-            'Set the degree to which an area is filled with laser lines or dots. The minimal interval is 0.05 mm.',
+            'Set the degree to which an area is filled with laser lines or dots. The minimal interval is 0.01 mm.',
         type: 'float',
-        min: 0.05,
+        min: 0.01,
         // max: 1,
         step: 0.01,
         default_value: 0.25,

--- a/src/app/flux/editor/index.ts
+++ b/src/app/flux/editor/index.ts
@@ -812,7 +812,7 @@ export const actions = {
         } else {
             const extname = path.extname(uploadName);
             const isScale = !includes(scaleExtname, extname);
-            const newModelSize = sourceType !== SOURCE_TYPE.IMAGE3D
+            const newModelSize = sourceType !== SOURCE_TYPE.IMAGE3D && sourceType !== SOURCE_TYPE.SVG
                 ? limitModelSizeByMachineSize(coordinateSize, sourceWidth, sourceHeight, isLimit, isScale)
                 : sizeModel(size, materials, sourceWidth, sourceHeight);
 


### PR DESCRIPTION
- [Fix: Update min line fill interval value 0.05 -> 0.0.1](https://github.com/Snapmaker/Luban/commit/b2dfaf7d9a39f31599b73781e011168091391a50)
- [Fix: SVG file size use original size](https://github.com/Snapmaker/Luban/commit/57a7205ec1751c20d76c31103c72f46e10166f93)
- [Improvement: Modify interlinked parameters for 3D printing support brim](https://github.com/Snapmaker/Luban/pull/2454/commits/4e805cff81f91601daf8f6e9f33252688d600c50)